### PR TITLE
Stamp per-entry VERSIONINFO; fix language ID leaking "Python" to Task Manager

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,12 @@ keywords = ["compiler", "executable", "exe", "packaging", "distribution"]
 dependencies = [
     "rich>=13.0",
 ]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pefile>=2023.0",
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",

--- a/src/coil/builder.py
+++ b/src/coil/builder.py
@@ -46,6 +46,7 @@ def build(
     verbose: bool = False,
     clean: bool = False,
     optimize: int | None = None,
+    versioninfo: dict[str, dict[str, str]] | None = None,
 ) -> list[Path]:
     """Execute the full build pipeline.
 
@@ -66,6 +67,7 @@ def build(
         verbose: Verbose output.
         clean: Build in a clean environment with only declared dependencies.
         optimize: Bytecode optimization level (0, 1, 2). None = auto.
+        versioninfo: Resolved per-entry VERSIONINFO fields, keyed by entry stem.
 
     Returns:
         List of paths to created output files/directories.
@@ -167,6 +169,7 @@ def build(
                 verbose=verbose,
                 ui=ui,
                 optimize=optimize,
+                versioninfo=versioninfo,
             )
             outputs = [result]
         else:
@@ -184,6 +187,7 @@ def build(
                 verbose=verbose,
                 ui=ui,
                 optimize=optimize,
+                versioninfo=versioninfo,
             )
 
     ui.build_summary(outputs)

--- a/src/coil/cli.py
+++ b/src/coil/cli.py
@@ -640,6 +640,28 @@ def main(argv: list[str] | None = None) -> None:
         if optimize is None:
             optimize = 2 if args.secure else 1
 
+        # Resolve per-entry VERSIONINFO from coil.toml if present.
+        versioninfo: dict[str, dict[str, str]] | None = None
+        from coil.config import load_config, get_versioninfo_config
+        raw_toml = load_config(project_dir)
+        if raw_toml is not None:
+            versioninfo = {}
+            for ep in entry_points:
+                stem = Path(ep).stem
+                versioninfo[stem] = get_versioninfo_config(
+                    raw_toml,
+                    entry_name=stem,
+                    project_name=name,
+                    project_dir=project_dir,
+                )
+            # For single-entry builds, the exe is named `name`, not the
+            # source stem. Duplicate the entry under that key so the
+            # packager finds it.
+            if len(entry_points) == 1:
+                only_stem = Path(entry_points[0]).stem
+                if name and name != only_stem:
+                    versioninfo[name] = versioninfo[only_stem]
+
         try:
             from coil.builder import build
             build(
@@ -659,6 +681,7 @@ def main(argv: list[str] | None = None) -> None:
                 verbose=args.verbose,
                 clean=args.clean,
                 optimize=optimize,
+                versioninfo=versioninfo,
             )
         except Exception as e:
             if args.verbose:

--- a/src/coil/config.py
+++ b/src/coil/config.py
@@ -51,6 +51,100 @@ def load_config(project_dir: Path) -> Optional[dict[str, Any]]:
         return tomllib.load(f)
 
 
+def _resolve_project_version(raw: dict[str, Any], project_dir: Optional[Path]) -> str:
+    """Return the project version string.
+
+    Priority: [project].version > version.txt at project root > "".
+    """
+    project = raw.get("project", {})
+    version = project.get("version", "")
+    if version:
+        return str(version).strip()
+    if project_dir is not None:
+        version_txt = project_dir / "version.txt"
+        if version_txt.is_file():
+            return version_txt.read_text(encoding="utf-8").strip()
+    return ""
+
+
+def _pad_version(version: str) -> str:
+    """Pad a version string to 4 dot-separated parts (e.g. "1.2" -> "1.2.0.0").
+
+    Accepts hyphen as separator. Non-numeric parts become 0.
+    """
+    if not version:
+        return "1.0.0.0"
+    parts = version.replace("-", ".").split(".")
+    nums = []
+    for p in parts[:4]:
+        try:
+            nums.append(str(int(p)))
+        except ValueError:
+            nums.append("0")
+    while len(nums) < 4:
+        nums.append("0")
+    return ".".join(nums)
+
+
+def get_versioninfo_config(
+    raw: dict[str, Any],
+    entry_name: str,
+    project_name: str,
+    project_dir: Optional[Path] = None,
+) -> dict[str, str]:
+    """Resolve VERSIONINFO fields for a single entry.
+
+    Merges shared [build.versioninfo] with per-entry
+    [build.versioninfo.entries.<stem>] overrides. Falls back to sensible
+    defaults derived from the entry name and project metadata.
+
+    Args:
+        raw: Parsed coil.toml.
+        entry_name: Entry point stem (e.g. "main" for "main.py"). For stems
+            with spaces, TOML requires quoted keys: ["With Spaces"].
+        project_name: Project name (from [project].name or directory name).
+        project_dir: Project directory, used for version.txt fallback.
+
+    Returns:
+        Dict with keys matching set_version_info kwargs: product_name,
+        file_description, file_version, product_version, company_name,
+        legal_copyright, internal_name, original_filename.
+    """
+    build = raw.get("build", {})
+    vi = build.get("versioninfo", {}) or {}
+    per_entry = (vi.get("entries", {}) or {}).get(entry_name, {}) or {}
+
+    version = _resolve_project_version(raw, project_dir)
+    default_version = _pad_version(version) if version else "1.0.0.0"
+
+    def pick(key: str, default: str) -> str:
+        if key in per_entry and per_entry[key] not in (None, ""):
+            return str(per_entry[key])
+        if key in vi and vi[key] not in (None, ""):
+            return str(vi[key])
+        return default
+
+    product_name = pick("product_name", project_name or entry_name)
+    file_description = pick("file_description", entry_name)
+    internal_name = pick("internal_name", entry_name)
+    original_filename = pick("original_filename", f"{entry_name}.exe")
+    file_version = _pad_version(pick("file_version", default_version))
+    product_version = _pad_version(pick("product_version", file_version))
+    company_name = pick("company_name", "")
+    legal_copyright = pick("legal_copyright", "")
+
+    return {
+        "product_name": product_name,
+        "file_description": file_description,
+        "internal_name": internal_name,
+        "original_filename": original_filename,
+        "file_version": file_version,
+        "product_version": product_version,
+        "company_name": company_name,
+        "legal_copyright": legal_copyright,
+    }
+
+
 def get_build_config(
     raw: dict[str, Any],
     profile: Optional[str] = None,

--- a/src/coil/packager.py
+++ b/src/coil/packager.py
@@ -49,6 +49,7 @@ def package_portable(
     verbose: bool = False,
     ui: Optional[BuildUI] = None,
     optimize: Optional[int] = None,
+    versioninfo: Optional[dict[str, dict[str, str]]] = None,
 ) -> list[Path]:
     """Create a portable build: single self-contained .exe per entry point.
 
@@ -118,29 +119,44 @@ def package_portable(
                     print("  Creating portable archive...")
                 zip_data = _zip_directory(stage_dir)
 
-        # Step 3: Prepare bootloader stub (apply icon BEFORE appending zip,
-        # because UpdateResource rewrites the PE and would strip appended data)
+        # Step 3: Prepare bootloader stub (apply icon + versioninfo BEFORE
+        # appending zip — UpdateResource rewrites the PE and would strip
+        # appended data).
         from coil.bootloader import get_bootloader_stub
         bootloader_stub = get_bootloader_stub()
 
-        if icon and sys.platform == "win32":
-            from coil.platforms.windows import set_exe_icon
+        vi_fields = (versioninfo or {}).get(entry_name)
+
+        if sys.platform == "win32" and (icon or vi_fields):
             with tempfile.NamedTemporaryFile(suffix=".exe", delete=False) as tf:
                 tf.write(bootloader_stub)
                 stub_path = Path(tf.name)
             try:
-                set_exe_icon(stub_path, Path(icon))
+                if icon:
+                    from coil.platforms.windows import set_exe_icon
+                    try:
+                        set_exe_icon(stub_path, Path(icon))
+                        if ui is not None:
+                            ui.detail(f"Applied icon: {icon}")
+                        elif verbose:
+                            print(f"  Applied icon: {icon}")
+                    except Exception as e:
+                        if ui is not None:
+                            ui.warning(f"Could not apply icon: {e}")
+                        elif verbose:
+                            print(f"  Warning: Could not apply icon: {e}")
+
+                if vi_fields:
+                    from coil.platforms.windows import set_version_info
+                    try:
+                        set_version_info(stub_path, **vi_fields)
+                    except Exception as e:
+                        if ui is not None:
+                            ui.warning(f"Could not set version info: {e}")
+                        elif verbose:
+                            print(f"  Warning: Could not set version info: {e}")
+
                 stub = stub_path.read_bytes()
-                if ui is not None:
-                    ui.detail(f"Applied icon: {icon}")
-                elif verbose:
-                    print(f"  Applied icon: {icon}")
-            except Exception as e:
-                stub = bootloader_stub
-                if ui is not None:
-                    ui.warning(f"Could not apply icon: {e}")
-                elif verbose:
-                    print(f"  Warning: Could not apply icon: {e}")
             finally:
                 stub_path.unlink(missing_ok=True)
         else:
@@ -180,6 +196,7 @@ def package_bundled(
     verbose: bool = False,
     ui: Optional[BuildUI] = None,
     optimize: Optional[int] = None,
+    versioninfo: Optional[dict[str, dict[str, str]]] = None,
 ) -> Path:
     """Create a bundled build: directory with exe and supporting files.
 
@@ -214,6 +231,10 @@ def package_bundled(
     # Build the full directory for the first (primary) entry point
     entry = entry_points[0]
     entry_name = Path(entry).stem if len(entry_points) > 1 else name
+    # Look up by entry stem for multi-entry, or by the requested exe name
+    # for single-entry (which may differ from the source filename via --name).
+    primary_vi_key = Path(entry).stem if len(entry_points) > 1 else entry_name
+    primary_vi = (versioninfo or {}).get(primary_vi_key)
     _build_app_directory(
         project_dir=project_dir,
         stage_dir=bundle_dir,
@@ -227,6 +248,7 @@ def package_bundled(
         verbose=verbose,
         ui=ui,
         optimize=optimize,
+        versioninfo=primary_vi,
     )
 
     # For multiple entry points, create additional launchers
@@ -261,8 +283,12 @@ def package_bundled(
                     except Exception:
                         pass
                 from coil.platforms.windows import set_version_info
+                extra_vi = (versioninfo or {}).get(extra_name)
                 try:
-                    set_version_info(extra_exe, product_name=extra_name)
+                    if extra_vi:
+                        set_version_info(extra_exe, **extra_vi)
+                    else:
+                        set_version_info(extra_exe, product_name=extra_name)
                 except Exception:
                     pass
 
@@ -292,6 +318,7 @@ def _build_app_directory(
     verbose: bool,
     ui: Optional[BuildUI] = None,
     optimize: Optional[int] = None,
+    versioninfo: Optional[dict[str, str]] = None,
 ) -> None:
     """Build the full application directory structure.
 
@@ -419,7 +446,10 @@ def _build_app_directory(
     if target_exe.is_file() and sys.platform == "win32":
         from coil.platforms.windows import set_version_info
         try:
-            set_version_info(target_exe, product_name=entry_name)
+            if versioninfo:
+                set_version_info(target_exe, **versioninfo)
+            else:
+                set_version_info(target_exe, product_name=entry_name)
         except Exception:
             pass
 

--- a/src/coil/platforms/windows.py
+++ b/src/coil/platforms/windows.py
@@ -281,7 +281,9 @@ def set_version_info(
     file_version: str = "1.0.0.0",
     product_version: str = "1.0.0.0",
     company_name: str = "",
-    copyright_text: str = "",
+    legal_copyright: str = "",
+    internal_name: str | None = None,
+    original_filename: str | None = None,
 ) -> None:
     """Write VS_VERSION_INFO resource into a PE executable.
 
@@ -295,12 +297,18 @@ def set_version_info(
         file_version: File version string (e.g. "1.0.0.0").
         product_version: Product version string (e.g. "1.0.0.0").
         company_name: Company name for file properties.
-        copyright_text: Copyright string for file properties.
+        legal_copyright: Copyright string for file properties.
+        internal_name: InternalName field. Defaults to product_name.
+        original_filename: OriginalFilename field. Defaults to exe_path.name.
     """
     import ctypes
 
     if file_description is None:
         file_description = product_name
+    if internal_name is None:
+        internal_name = product_name
+    if original_filename is None:
+        original_filename = exe_path.name
 
     # Parse version into 4-part tuple
     def _parse_ver(v: str) -> tuple[int, int, int, int]:
@@ -348,15 +356,15 @@ def set_version_info(
     strings = {
         "FileDescription": file_description,
         "FileVersion": file_version,
-        "InternalName": product_name,
+        "InternalName": internal_name,
         "ProductName": product_name,
         "ProductVersion": product_version,
-        "OriginalFilename": exe_path.name,
+        "OriginalFilename": original_filename,
     }
     if company_name:
         strings["CompanyName"] = company_name
-    if copyright_text:
-        strings["LegalCopyright"] = copyright_text
+    if legal_copyright:
+        strings["LegalCopyright"] = legal_copyright
 
     # Build String entries
     string_entries = b''
@@ -395,9 +403,9 @@ def set_version_info(
     vfi += var_entry
     vfi = struct.pack('<H', len(vfi)) + vfi[2:]
 
-    # Build VS_FIXEDFILEINFO
+    # Build VS_FIXEDFILEINFO (13 DWORDs per the MS spec)
     fixed_info = struct.pack(
-        '<IIIIIIIIIIIIII',
+        '<IIIIIIIIIIIII',
         0xFEEF04BD,  # dwSignature
         0x00010000,  # dwStrucVersion
         (fv[0] << 16) | fv[1],  # dwFileVersionMS
@@ -425,9 +433,14 @@ def set_version_info(
     vs_root += vfi
     vs_root = struct.pack('<H', len(vs_root)) + vs_root[2:]
 
-    # Write to exe using UpdateResource
+    # Write to exe using UpdateResource.
+    # Must match the language ID of the existing VS_VERSION_INFO resource so we
+    # overwrite it rather than adding a second one. python.exe ships its
+    # VS_VERSION_INFO at 0x0409 (en-US); writing at LANG_NEUTRAL (0) leaves the
+    # original in place and Windows picks the en-US one first, so FileDescription
+    # still reads "Python".
     RT_VERSION = 16
-    LANG_NEUTRAL = 0
+    LANG_EN_US = 0x0409
 
     kernel32 = ctypes.windll.kernel32
     kernel32.BeginUpdateResourceW.argtypes = [ctypes.c_wchar_p, ctypes.c_bool]
@@ -447,7 +460,7 @@ def set_version_info(
     try:
         buf = ctypes.create_string_buffer(vs_root)
         ok = kernel32.UpdateResourceW(
-            handle, RT_VERSION, 1, LANG_NEUTRAL, buf, len(vs_root),
+            handle, RT_VERSION, 1, LANG_EN_US, buf, len(vs_root),
         )
         if not ok:
             raise OSError(f"UpdateResource RT_VERSION failed (error {ctypes.GetLastError()})")

--- a/tests/fixtures/versioninfo_sample/With Spaces.py
+++ b/tests/fixtures/versioninfo_sample/With Spaces.py
@@ -1,0 +1,1 @@
+print("with spaces")

--- a/tests/fixtures/versioninfo_sample/coil.toml
+++ b/tests/fixtures/versioninfo_sample/coil.toml
@@ -1,0 +1,23 @@
+[project]
+name = "AcmeSuite"
+version = "1.2.3"
+
+[build]
+mode = "bundled"
+os = "windows"
+console = true
+
+[build.versioninfo]
+company_name = "Acme Corp"
+product_name = "Acme Suite"
+legal_copyright = "Copyright (c) 2026 Acme Corp"
+
+[build.versioninfo.entries.main]
+file_description = "Acme Suite - Main Tool"
+
+[build.versioninfo.entries.worker]
+file_description = "Acme Suite - Worker"
+internal_name = "acme-worker"
+
+[build.versioninfo.entries."With Spaces"]
+file_description = "Acme Suite - Spaced Tool"

--- a/tests/fixtures/versioninfo_sample/main.py
+++ b/tests/fixtures/versioninfo_sample/main.py
@@ -1,0 +1,1 @@
+print("main")

--- a/tests/fixtures/versioninfo_sample/worker.py
+++ b/tests/fixtures/versioninfo_sample/worker.py
@@ -1,0 +1,1 @@
+print("worker")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,14 @@ from pathlib import Path
 
 import pytest
 
-from coil.config import load_config, get_build_config, generate_toml
+from coil.config import (
+    load_config,
+    get_build_config,
+    generate_toml,
+    get_versioninfo_config,
+    _pad_version,
+    _resolve_project_version,
+)
 
 
 def test_load_config_no_file(tmp_path: Path):
@@ -137,6 +144,212 @@ def test_generate_toml_commented_profiles():
     assert "profile.release" in toml
     # Should be commented out
     assert "# [profile.dev]" in toml
+
+
+def test_pad_version_short():
+    assert _pad_version("1.2") == "1.2.0.0"
+
+
+def test_pad_version_full():
+    assert _pad_version("1.2.3.4") == "1.2.3.4"
+
+
+def test_pad_version_too_long():
+    assert _pad_version("1.2.3.4.5") == "1.2.3.4"
+
+
+def test_pad_version_empty():
+    assert _pad_version("") == "1.0.0.0"
+
+
+def test_pad_version_nonnumeric():
+    assert _pad_version("1.2.rc1") == "1.2.0.0"
+
+
+def test_pad_version_hyphen():
+    assert _pad_version("1.2-3") == "1.2.3.0"
+
+
+def test_resolve_project_version_from_toml(tmp_path: Path):
+    raw = {"project": {"version": "2.0.1"}}
+    assert _resolve_project_version(raw, tmp_path) == "2.0.1"
+
+
+def test_resolve_project_version_from_version_txt(tmp_path: Path):
+    (tmp_path / "version.txt").write_text("3.4.5\n", encoding="utf-8")
+    raw = {"project": {}}
+    assert _resolve_project_version(raw, tmp_path) == "3.4.5"
+
+
+def test_resolve_project_version_toml_wins_over_version_txt(tmp_path: Path):
+    (tmp_path / "version.txt").write_text("3.4.5", encoding="utf-8")
+    raw = {"project": {"version": "9.9.9"}}
+    assert _resolve_project_version(raw, tmp_path) == "9.9.9"
+
+
+def test_resolve_project_version_absent(tmp_path: Path):
+    raw = {"project": {}}
+    assert _resolve_project_version(raw, tmp_path) == ""
+
+
+def test_versioninfo_no_config_defaults():
+    """With no [build.versioninfo] block, everything is derived."""
+    raw = {"project": {"name": "MyApp"}}
+    vi = get_versioninfo_config(raw, entry_name="main", project_name="MyApp")
+    assert vi["product_name"] == "MyApp"
+    assert vi["file_description"] == "main"
+    assert vi["internal_name"] == "main"
+    assert vi["original_filename"] == "main.exe"
+    assert vi["file_version"] == "1.0.0.0"
+    assert vi["product_version"] == "1.0.0.0"
+    assert vi["company_name"] == ""
+    assert vi["legal_copyright"] == ""
+
+
+def test_versioninfo_shared_fields_applied_to_all_entries():
+    raw = {
+        "project": {"name": "Suite", "version": "2.1"},
+        "build": {
+            "versioninfo": {
+                "company_name": "Acme",
+                "legal_copyright": "(c) 2026 Acme",
+            }
+        },
+    }
+    a = get_versioninfo_config(raw, entry_name="main", project_name="Suite")
+    b = get_versioninfo_config(raw, entry_name="worker", project_name="Suite")
+    assert a["company_name"] == "Acme"
+    assert b["company_name"] == "Acme"
+    assert a["legal_copyright"] == "(c) 2026 Acme"
+    assert b["legal_copyright"] == "(c) 2026 Acme"
+    # Version padded from project.version
+    assert a["file_version"] == "2.1.0.0"
+    assert b["product_version"] == "2.1.0.0"
+
+
+def test_versioninfo_per_entry_override():
+    raw = {
+        "project": {"name": "Suite"},
+        "build": {
+            "versioninfo": {
+                "product_name": "Acme Suite",
+                "entries": {
+                    "main": {"file_description": "Acme Main"},
+                    "worker": {
+                        "file_description": "Acme Worker",
+                        "internal_name": "acme-worker",
+                    },
+                },
+            }
+        },
+    }
+    a = get_versioninfo_config(raw, entry_name="main", project_name="Suite")
+    b = get_versioninfo_config(raw, entry_name="worker", project_name="Suite")
+    assert a["product_name"] == "Acme Suite"
+    assert a["file_description"] == "Acme Main"
+    assert a["internal_name"] == "main"  # default — not overridden
+    assert b["product_name"] == "Acme Suite"  # shared
+    assert b["file_description"] == "Acme Worker"
+    assert b["internal_name"] == "acme-worker"
+
+
+def test_versioninfo_version_txt_fallback(tmp_path: Path):
+    (tmp_path / "version.txt").write_text("4.5.6", encoding="utf-8")
+    raw = {"project": {"name": "App"}}
+    vi = get_versioninfo_config(
+        raw, entry_name="main", project_name="App", project_dir=tmp_path
+    )
+    assert vi["file_version"] == "4.5.6.0"
+    assert vi["product_version"] == "4.5.6.0"
+
+
+def test_versioninfo_quoted_stem_with_spaces():
+    """TOML requires quoted keys for stems containing spaces."""
+    raw = {
+        "project": {"name": "Suite"},
+        "build": {
+            "versioninfo": {
+                "entries": {
+                    "With Spaces": {"file_description": "Spaced Tool"},
+                }
+            }
+        },
+    }
+    vi = get_versioninfo_config(
+        raw, entry_name="With Spaces", project_name="Suite"
+    )
+    assert vi["file_description"] == "Spaced Tool"
+    # Defaults still derive from the stem verbatim
+    assert vi["internal_name"] == "With Spaces"
+    assert vi["original_filename"] == "With Spaces.exe"
+
+
+def test_versioninfo_quoted_stem_parses_from_toml(tmp_path: Path):
+    """Roundtrip: write TOML with a quoted spaced-stem key, parse it back."""
+    toml = (
+        '[project]\nname = "Suite"\nentry = ["With Spaces.py"]\n'
+        '[build.versioninfo.entries."With Spaces"]\n'
+        'file_description = "Spaced"\n'
+    )
+    (tmp_path / "coil.toml").write_text(toml, encoding="utf-8")
+    raw = load_config(tmp_path)
+    assert raw is not None
+    vi = get_versioninfo_config(
+        raw, entry_name="With Spaces", project_name="Suite"
+    )
+    assert vi["file_description"] == "Spaced"
+
+
+def test_versioninfo_entry_overrides_shared():
+    raw = {
+        "project": {"name": "Suite"},
+        "build": {
+            "versioninfo": {
+                "product_name": "Shared Product",
+                "company_name": "Shared Co",
+                "entries": {
+                    "main": {
+                        "product_name": "Main Only Product",
+                        "company_name": "Main Only Co",
+                    },
+                },
+            }
+        },
+    }
+    vi = get_versioninfo_config(raw, entry_name="main", project_name="Suite")
+    assert vi["product_name"] == "Main Only Product"
+    assert vi["company_name"] == "Main Only Co"
+
+
+def test_versioninfo_product_name_defaults_to_project_name():
+    raw = {"project": {"name": "MyProject"}}
+    vi = get_versioninfo_config(raw, entry_name="helper", project_name="MyProject")
+    assert vi["product_name"] == "MyProject"
+
+
+def test_versioninfo_product_version_defaults_to_file_version():
+    raw = {
+        "project": {"name": "Suite"},
+        "build": {"versioninfo": {"file_version": "5.6.7.8"}},
+    }
+    vi = get_versioninfo_config(raw, entry_name="main", project_name="Suite")
+    assert vi["file_version"] == "5.6.7.8"
+    assert vi["product_version"] == "5.6.7.8"
+
+
+def test_versioninfo_explicit_product_version_wins():
+    raw = {
+        "project": {"name": "Suite"},
+        "build": {
+            "versioninfo": {
+                "file_version": "1.0",
+                "product_version": "2.0",
+            }
+        },
+    }
+    vi = get_versioninfo_config(raw, entry_name="main", project_name="Suite")
+    assert vi["file_version"] == "1.0.0.0"
+    assert vi["product_version"] == "2.0.0.0"
 
 
 def test_roundtrip_generate_then_load(tmp_path: Path):

--- a/tests/test_versioninfo_integration.py
+++ b/tests/test_versioninfo_integration.py
@@ -1,0 +1,175 @@
+"""End-to-end test: build the fixture and verify each exe's VERSIONINFO.
+
+Uses a real Python runtime (copied from the host interpreter) so target
+exes are stampable PEs. Parses the produced exes with pefile.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32", reason="VERSIONINFO stamping is Windows-only"
+)
+
+pefile = pytest.importorskip("pefile")
+
+from coil.config import get_versioninfo_config, load_config
+from coil.packager import package_bundled
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "versioninfo_sample"
+
+
+def _make_real_runtime(tmp_path: Path) -> Path:
+    """Build a synthetic embeddable-like runtime with a real python.exe + DLLs."""
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    host_dir = Path(sys.executable).parent
+
+    for exe_name in ("python.exe", "pythonw.exe"):
+        src = host_dir / exe_name
+        if src.is_file():
+            shutil.copy2(src, runtime / exe_name)
+
+    for pattern in ("python*.dll", "vcruntime*.dll"):
+        for dll in host_dir.glob(pattern):
+            shutil.copy2(dll, runtime / dll.name)
+
+    ver_tag = f"{sys.version_info.major}{sys.version_info.minor}"
+    (runtime / f"python{ver_tag}._pth").write_text(f"python{ver_tag}.zip\n.\n")
+
+    # Minimal valid (empty) zip so _strip_stdlib_zip is a no-op.
+    import zipfile
+    zip_path = runtime / f"python{ver_tag}.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        pass
+
+    return runtime
+
+
+def _read_version_strings(exe_path: Path) -> dict[str, str]:
+    pe = pefile.PE(str(exe_path), fast_load=True)
+    pe.parse_data_directories(
+        directories=[pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_RESOURCE"]]
+    )
+    result: dict[str, str] = {}
+    if not hasattr(pe, "FileInfo") or not pe.FileInfo:
+        pe.close()
+        return result
+    for file_info_list in pe.FileInfo:
+        for file_info in file_info_list:
+            if getattr(file_info, "Key", b"") == b"StringFileInfo":
+                for st in file_info.StringTable:
+                    for k, v in st.entries.items():
+                        key = k.decode("utf-8", "replace") if isinstance(k, bytes) else k
+                        val = v.decode("utf-8", "replace") if isinstance(v, bytes) else v
+                        result[key] = val
+    pe.close()
+    return result
+
+
+def test_bundled_build_stamps_versioninfo_from_fixture(tmp_path: Path, monkeypatch):
+    """Full pipeline: parse fixture coil.toml, build, verify each exe.
+
+    Mocks the .pyc compilation step — we're testing VERSIONINFO wiring,
+    not the compiler.
+    """
+    raw = load_config(FIXTURE_DIR)
+    assert raw is not None
+
+    entries = ["main.py", "worker.py", "With Spaces.py"]
+    stems = [Path(e).stem for e in entries]
+
+    versioninfo = {
+        stem: get_versioninfo_config(
+            raw,
+            entry_name=stem,
+            project_name="AcmeSuite",
+            project_dir=FIXTURE_DIR,
+        )
+        for stem in stems
+    }
+
+    # Skip real compilation: we don't need real .pyc files for this test.
+    def _fake_obfuscate(project_dir, internal_dir, ui=None, optimize=0, runtime_python=None):
+        app_dir = internal_dir / "app"
+        app_dir.mkdir(parents=True, exist_ok=True)
+        for src in project_dir.glob("*.py"):
+            (app_dir / (src.stem + ".pyc")).write_bytes(b"")
+
+    monkeypatch.setattr("coil.packager.obfuscate_default", _fake_obfuscate)
+    monkeypatch.setattr("coil.packager.obfuscate_secure", _fake_obfuscate)
+
+    runtime = _make_real_runtime(tmp_path)
+    output = tmp_path / "dist"
+
+    bundle = package_bundled(
+        project_dir=FIXTURE_DIR,
+        output_dir=output,
+        runtime_dir=runtime,
+        entry_points=entries,
+        name="AcmeSuite",
+        target_os="windows",
+        versioninfo=versioninfo,
+    )
+    assert bundle.is_dir()
+
+    # Primary entry keeps bundle name for single-entry naming, but with
+    # multiple entries each gets its stem. Check each.
+    expected = {
+        "main.exe": {
+            "ProductName": "Acme Suite",
+            "FileDescription": "Acme Suite - Main Tool",
+            "CompanyName": "Acme Corp",
+            "LegalCopyright": "Copyright (c) 2026 Acme Corp",
+            "FileVersion": "1.2.3.0",
+            "ProductVersion": "1.2.3.0",
+            "InternalName": "main",
+            "OriginalFilename": "main.exe",
+        },
+        "worker.exe": {
+            "ProductName": "Acme Suite",
+            "FileDescription": "Acme Suite - Worker",
+            "CompanyName": "Acme Corp",
+            "InternalName": "acme-worker",
+            "OriginalFilename": "worker.exe",
+        },
+        "With Spaces.exe": {
+            "ProductName": "Acme Suite",
+            "FileDescription": "Acme Suite - Spaced Tool",
+            "CompanyName": "Acme Corp",
+            "InternalName": "With Spaces",
+            "OriginalFilename": "With Spaces.exe",
+        },
+    }
+
+    for exe_name, want in expected.items():
+        exe = bundle / exe_name
+        assert exe.is_file(), f"expected {exe_name} in {bundle}"
+        got = _read_version_strings(exe)
+        for key, value in want.items():
+            assert got.get(key) == value, (
+                f"{exe_name}: {key} expected {value!r}, got {got.get(key)!r}"
+            )
+        # Canary: must not have inherited python.exe's FileDescription
+        assert got["FileDescription"].lower() != "python"
+
+
+def test_bundled_build_with_quoted_stem_loads_and_stamps(tmp_path: Path):
+    """Directly exercise the quoted-stem path via load_config round-trip."""
+    raw = load_config(FIXTURE_DIR)
+    assert raw is not None
+    vi = get_versioninfo_config(
+        raw,
+        entry_name="With Spaces",
+        project_name="AcmeSuite",
+        project_dir=FIXTURE_DIR,
+    )
+    assert vi["file_description"] == "Acme Suite - Spaced Tool"
+    assert vi["file_version"] == "1.2.3.0"
+    assert vi["product_name"] == "Acme Suite"

--- a/tests/test_windows_versioninfo.py
+++ b/tests/test_windows_versioninfo.py
@@ -1,0 +1,167 @@
+"""Tests for the VS_VERSION_INFO writer on Windows.
+
+Validates that set_version_info replaces (not coexists with) the existing
+VS_VERSION_INFO resource that python.exe ships with. The roundtrip uses
+pefile so the writer's ctypes code isn't trusted to self-validate.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32", reason="VERSIONINFO writer is Windows-only"
+)
+
+pefile = pytest.importorskip("pefile")
+
+from coil.platforms.windows import set_version_info
+
+
+def _copy_python_exe(tmp_path: Path, name: str = "sample.exe") -> Path:
+    """Copy the running Python interpreter to a temp path as a realistic PE."""
+    src = Path(sys.executable)
+    dest = tmp_path / name
+    shutil.copy2(src, dest)
+    return dest
+
+
+def _read_version_strings(exe_path: Path) -> dict[str, str]:
+    """Parse VS_VERSION_INFO strings out of a PE using pefile."""
+    pe = pefile.PE(str(exe_path), fast_load=True)
+    pe.parse_data_directories(
+        directories=[pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_RESOURCE"]]
+    )
+    result: dict[str, str] = {}
+    if not hasattr(pe, "FileInfo") or not pe.FileInfo:
+        pe.close()
+        return result
+    for file_info_list in pe.FileInfo:
+        for file_info in file_info_list:
+            if getattr(file_info, "Key", b"") == b"StringFileInfo":
+                for st in file_info.StringTable:
+                    for k, v in st.entries.items():
+                        key = k.decode("utf-8", "replace") if isinstance(k, bytes) else k
+                        val = v.decode("utf-8", "replace") if isinstance(v, bytes) else v
+                        result[key] = val
+    pe.close()
+    return result
+
+
+def _read_version_languages(exe_path: Path) -> list[int]:
+    """Return the list of language IDs carrying an RT_VERSION resource."""
+    pe = pefile.PE(str(exe_path), fast_load=True)
+    pe.parse_data_directories(
+        directories=[pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_RESOURCE"]]
+    )
+    langs: list[int] = []
+    rt_version = pefile.RESOURCE_TYPE["RT_VERSION"]
+    for entry in pe.DIRECTORY_ENTRY_RESOURCE.entries:
+        if entry.id != rt_version:
+            continue
+        for name_entry in entry.directory.entries:
+            for lang_entry in name_entry.directory.entries:
+                langs.append(lang_entry.id)
+    pe.close()
+    return langs
+
+
+def test_writer_replaces_rather_than_adds(tmp_path: Path):
+    """The fix: we write at lang 0x0409 so there's only ONE RT_VERSION after."""
+    exe = _copy_python_exe(tmp_path)
+    before = _read_version_languages(exe)
+    assert before, "python.exe should have an existing VS_VERSION_INFO"
+
+    set_version_info(exe, product_name="MyProduct", file_description="My Tool")
+
+    after = _read_version_languages(exe)
+    # Writing at the same language ID as the pre-existing resource (0x0409)
+    # means we have exactly as many RT_VERSION entries as before, not one more.
+    assert after == before
+    # And at least one of them is 0x0409 (en-US).
+    assert 0x0409 in after
+
+
+def test_writer_stamps_all_fields(tmp_path: Path):
+    exe = _copy_python_exe(tmp_path, "app.exe")
+    set_version_info(
+        exe,
+        product_name="Acme Suite",
+        file_description="Acme Main Tool",
+        file_version="1.2.3.4",
+        product_version="1.2.0.0",
+        company_name="Acme Corp",
+        legal_copyright="Copyright (c) 2026 Acme Corp",
+        internal_name="acme-main",
+        original_filename="app.exe",
+    )
+
+    strings = _read_version_strings(exe)
+    assert strings["ProductName"] == "Acme Suite"
+    assert strings["FileDescription"] == "Acme Main Tool"
+    assert strings["FileVersion"] == "1.2.3.4"
+    assert strings["ProductVersion"] == "1.2.0.0"
+    assert strings["CompanyName"] == "Acme Corp"
+    assert strings["LegalCopyright"] == "Copyright (c) 2026 Acme Corp"
+    assert strings["InternalName"] == "acme-main"
+    assert strings["OriginalFilename"] == "app.exe"
+
+
+def test_writer_evicts_python_filedescription(tmp_path: Path):
+    """Before the fix, FileDescription still read 'Python' after stamping.
+
+    This is the canary test for the language ID bug.
+    """
+    exe = _copy_python_exe(tmp_path)
+    before = _read_version_strings(exe)
+    # Sanity: python.exe ships with FileDescription "Python"
+    assert before.get("FileDescription", "").lower().startswith("python")
+
+    set_version_info(exe, product_name="NotPython", file_description="NotPython")
+
+    after = _read_version_strings(exe)
+    assert after.get("FileDescription") == "NotPython"
+    assert after.get("FileDescription", "").lower() != "python"
+
+
+def test_writer_defaults(tmp_path: Path):
+    """Omitted fields fall back to reasonable defaults."""
+    exe = _copy_python_exe(tmp_path, "Thing.exe")
+    set_version_info(exe, product_name="Thing")
+
+    strings = _read_version_strings(exe)
+    assert strings["ProductName"] == "Thing"
+    # file_description falls back to product_name
+    assert strings["FileDescription"] == "Thing"
+    # internal_name falls back to product_name
+    assert strings["InternalName"] == "Thing"
+    # original_filename falls back to exe filename
+    assert strings["OriginalFilename"] == "Thing.exe"
+
+
+def test_writer_unicode_values(tmp_path: Path):
+    """Non-ASCII values roundtrip correctly (UTF-16 LE path)."""
+    exe = _copy_python_exe(tmp_path)
+    set_version_info(
+        exe,
+        product_name="Ácme Suíte",
+        file_description="Tëst — App",
+        company_name="Ünicode Corp",
+    )
+    strings = _read_version_strings(exe)
+    assert strings["ProductName"] == "Ácme Suíte"
+    assert strings["FileDescription"] == "Tëst — App"
+    assert strings["CompanyName"] == "Ünicode Corp"
+
+
+def test_writer_omits_empty_optional_fields(tmp_path: Path):
+    """Empty company_name / legal_copyright are not written as blank strings."""
+    exe = _copy_python_exe(tmp_path)
+    set_version_info(exe, product_name="Thing")
+    strings = _read_version_strings(exe)
+    assert "CompanyName" not in strings
+    assert "LegalCopyright" not in strings


### PR DESCRIPTION
## Summary

- **Root-cause fix:** `set_version_info` was writing its `VS_VERSION_INFO` resource at `LANG_NEUTRAL` (0) while python.exe ships its resource at `0x0409` (en-US). `BeginUpdateResourceW` was called with `bDeleteExistingResources=False`, so the original en-US "Python" resource survived and Windows preferred it — Task Manager still read `FileDescription="Python"` for every Coil-built exe. Writing at `0x0409` replaces it.
- **Latent bug fix:** `VS_FIXEDFILEINFO` was packed as `<IIIIIIIIIIIIII` (14 DWORDs) with only 13 values. The spec has 13. The new pefile roundtrip tests surfaced this; previously the packager's `try/except: pass` around `set_version_info` hid it, which is partly why the original stamping attempt was ineffective.
- **New config surface** for per-entry VERSIONINFO in `coil.toml` — shared fields under `[build.versioninfo]`, per-entry overrides under `[build.versioninfo.entries.<stem>]`. Stems with spaces require quoted TOML keys (fixture covers `"With Spaces"`).
- **Project version resolution:** `[project].version`, falling back to a `version.txt` at the project root. Defaults synthesize sensibly from entry name + project name so zero-config still works.
- **Portable mode now stamps too** — the stamp happens on the bootloader stub between icon-apply and zip-append, same ordering rule that already applied to icons.

## Test plan

- [x] Unit tests for the writer (`tests/test_windows_versioninfo.py`) — copy `sys.executable` to a temp path, stamp via `set_version_info`, parse back with `pefile`. Includes a canary test that `FileDescription` no longer reads "Python" and that we have the same number of `RT_VERSION` entries (not one more).
- [x] Unit tests for config resolution (`tests/test_config.py`) — shared-only, per-entry override, defaults, `version.txt` fallback, and TOML roundtrip of a quoted-stem entry.
- [x] Integration test (`tests/test_versioninfo_integration.py`) — builds the fixture (`tests/fixtures/versioninfo_sample/` with `main.py`, `worker.py`, `With Spaces.py`) end-to-end and asserts each produced exe has the expected VERSIONINFO strings.
- [x] Empirical PowerShell check: `(Get-Item <exe>).VersionInfo.FileDescription` returns `"Acme Canary Tool"` (stamped value) rather than `"Python"`. This is what Task Manager reads.
- [x] Full test run: 227 passed, 9 failed — the 9 failures are pre-existing on `master` (verified by `git stash` + rerun). Not touched by this PR.

## Out of scope

Explicitly not included (separate PRs): TOML multi-entry auto-detection, `.pth` handling, REPL-hang on `__main__` return, PE subsystem selection. Not rebuilding downstream apps — acceptance is tests + mock-compile integration only; the downstream rebuild happens after this ships to PyPI.