### PR TITLE
Resolve imports via importlib.metadata.packages_distributions()

### DIFF
--- a/src/coil/builder.py
+++ b/src/coil/builder.py
@@ -47,6 +47,7 @@ def build(
     clean: bool = False,
     optimize: int | None = None,
     versioninfo: dict[str, dict[str, str]] | None = None,
+    deps_auto: bool = True,
 ) -> list[Path]:
     """Execute the full build pipeline.
 
@@ -68,6 +69,8 @@ def build(
         clean: Build in a clean environment with only declared dependencies.
         optimize: Bytecode optimization level (0, 1, 2). None = auto.
         versioninfo: Resolved per-entry VERSIONINFO fields, keyed by entry stem.
+        deps_auto: When True, auto-detect imports and union with declared
+            dependencies. Reflects [build.dependencies].auto in coil.toml.
 
     Returns:
         List of paths to created output files/directories.
@@ -95,6 +98,8 @@ def build(
         requirements_path=requirements,
         exclude=exclude,
         include=include,
+        auto=deps_auto,
+        warn=ui.warning,
     )
     if packages:
         ui.detail(f"Found {len(packages)} dependencies: {', '.join(packages)}")

--- a/src/coil/cli.py
+++ b/src/coil/cli.py
@@ -642,9 +642,15 @@ def main(argv: list[str] | None = None) -> None:
 
         # Resolve per-entry VERSIONINFO from coil.toml if present.
         versioninfo: dict[str, dict[str, str]] | None = None
-        from coil.config import load_config, get_versioninfo_config
+        deps_auto = True
+        from coil.config import load_config, get_build_config, get_versioninfo_config
         raw_toml = load_config(project_dir)
         if raw_toml is not None:
+            try:
+                _build_cfg = get_build_config(raw_toml, profile=args.profile)
+                deps_auto = bool(_build_cfg.get("deps_auto", True))
+            except ValueError:
+                pass
             versioninfo = {}
             for ep in entry_points:
                 stem = Path(ep).stem
@@ -682,6 +688,7 @@ def main(argv: list[str] | None = None) -> None:
                 clean=args.clean,
                 optimize=optimize,
                 versioninfo=versioninfo,
+                deps_auto=deps_auto,
             )
         except Exception as e:
             if args.verbose:

--- a/src/coil/resolver.py
+++ b/src/coil/resolver.py
@@ -1,10 +1,12 @@
 """Dependency resolution for Python projects."""
 
+import importlib.metadata
 import re
+from collections.abc import Callable
 from pathlib import Path
 
 from coil.scanner import scan_project
-from coil.utils.package_map import resolve_package_name
+from coil.utils.package_map import IMPORT_TO_PYPI
 from coil.utils.stdlib_list import get_stdlib_modules
 
 
@@ -47,71 +49,146 @@ def parse_pyproject_toml(path: Path) -> list[str]:
     return packages
 
 
+def _build_dist_map() -> dict[str, list[str]]:
+    """Return {top_level_module: sorted_distribution_names} for the current env.
+
+    Wraps ``importlib.metadata.packages_distributions()`` and sorts each value
+    so that multi-distribution resolution is deterministic. Returns an empty
+    dict if metadata lookup fails.
+    """
+    try:
+        raw = importlib.metadata.packages_distributions()
+    except Exception:
+        return {}
+    return {mod: sorted(dists) for mod, dists in raw.items()}
+
+
+def resolve_from_imports(
+    project_dir: Path,
+    python_version: str,
+    dist_map: dict[str, list[str]] | None = None,
+    warn: Callable[[str], None] | None = None,
+) -> list[str]:
+    """Resolve third-party distribution names from the project's imports.
+
+    Walks every ``.py`` file under ``project_dir``, filters out stdlib and
+    first-party modules, and maps each remaining top-level module name to a
+    PyPI distribution name.
+
+    Mapping strategy (per module):
+
+    1. If ``dist_map`` has an entry for the module, use the first distribution
+       in sorted order. If there is more than one, call ``warn`` with a
+       one-line message so the caller can surface the ambiguity.
+    2. Otherwise, fall back to the hand-maintained ``IMPORT_TO_PYPI`` map.
+       This only fires for modules that aren't installed in Coil's own env
+       — the typical fresh-clone case.
+    3. If neither has an entry, assume the distribution name equals the
+       module name.
+
+    A single distribution that exposes several top-level modules (e.g. pywin32
+    ships ``win32api``, ``win32file``, ``win32pipe``, ``pywintypes``, ...) is
+    naturally deduplicated because all of its modules map to the same name.
+    """
+    if dist_map is None:
+        dist_map = _build_dist_map()
+
+    stdlib = get_stdlib_modules(python_version)
+    local = _get_local_modules(project_dir)
+    imports = scan_project(project_dir) - stdlib - local
+
+    result: set[str] = set()
+    for mod in sorted(imports):
+        dists = dist_map.get(mod)
+        if dists:
+            chosen = dists[0]
+            if len(dists) > 1 and warn is not None:
+                warn(
+                    f"Module '{mod}' is provided by multiple distributions "
+                    f"({', '.join(dists)}); using '{chosen}'."
+                )
+            result.add(chosen)
+            continue
+        mapped = IMPORT_TO_PYPI.get(mod)
+        if mapped is not None:
+            result.add(mapped)
+        else:
+            result.add(mod)
+    return sorted(result)
+
+
 def resolve_dependencies(
     project_dir: Path,
     python_version: str,
     requirements_path: str | None = None,
     exclude: list[str] | None = None,
     include: list[str] | None = None,
+    auto: bool = True,
+    dist_map: dict[str, list[str]] | None = None,
+    warn: Callable[[str], None] | None = None,
 ) -> list[str]:
     """Resolve all third-party dependencies for a project.
 
-    Priority order:
-    1. Explicit requirements path (--requirements flag)
-    2. requirements.txt in project dir
-    3. pyproject.toml with dependencies in project dir
-    4. AST-based import scanning
+    Sources, in order:
+
+    1. An explicit ``requirements_path`` — exclusive source (legacy escape
+       hatch). Still unioned with ``include`` at the end.
+    2. ``requirements.txt`` in ``project_dir`` — same: exclusive when present.
+    3. Otherwise, unions:
+       - ``[project].dependencies`` from ``pyproject.toml`` (if present),
+       - Imports auto-detected from project source (when ``auto`` is True),
+       - Anything in ``include``.
+
+    ``exclude`` trims the final set as the last step, regardless of source.
+
+    Auto-detection is additive: it never drops version pins declared in
+    ``[project].dependencies``.
 
     Args:
         project_dir: Path to the project directory.
         python_version: Target Python version (e.g. "3.12").
-        requirements_path: Explicit path to requirements file.
-        exclude: Package names to exclude.
+        requirements_path: Explicit path to a requirements file.
+        exclude: Package names to exclude (case-insensitive).
         include: Package names to force-include.
+        auto: When True, auto-detect imports and union with declared deps.
+        dist_map: Override for ``importlib.metadata.packages_distributions()``
+            (primarily for tests). When None, introspects the current env.
+        warn: Optional one-arg callable for non-fatal warnings (e.g.
+            ambiguous multi-distribution resolutions).
 
     Returns:
-        Sorted list of PyPI package names.
+        Sorted list of PyPI distribution names.
     """
     exclude = exclude or []
     include = include or []
-    packages: list[str] = []
+    packages: set[str] = set()
 
-    # Priority 1: explicit requirements path
     if requirements_path:
         req_path = Path(requirements_path)
         if req_path.name.endswith(".toml"):
-            packages = parse_pyproject_toml(req_path)
+            packages.update(parse_pyproject_toml(req_path))
         else:
-            packages = parse_requirements_txt(req_path)
-
-    # Priority 2: requirements.txt in project dir
+            packages.update(parse_requirements_txt(req_path))
     elif (project_dir / "requirements.txt").is_file():
-        packages = parse_requirements_txt(project_dir / "requirements.txt")
-
-    # Priority 3: pyproject.toml in project dir
-    elif (project_dir / "pyproject.toml").is_file():
-        packages = parse_pyproject_toml(project_dir / "pyproject.toml")
-
-    # Priority 4: AST scan
+        packages.update(parse_requirements_txt(project_dir / "requirements.txt"))
     else:
-        stdlib = get_stdlib_modules(python_version)
-        all_imports = scan_project(project_dir)
+        pyproject = project_dir / "pyproject.toml"
+        if pyproject.is_file():
+            packages.update(parse_pyproject_toml(pyproject))
+        if auto:
+            packages.update(
+                resolve_from_imports(
+                    project_dir,
+                    python_version,
+                    dist_map=dist_map,
+                    warn=warn,
+                )
+            )
 
-        # Filter out stdlib and local project modules
-        local_modules = _get_local_modules(project_dir)
-        third_party = all_imports - stdlib - local_modules
+    packages.update(include)
 
-        packages = [resolve_package_name(name) for name in third_party]
-
-    # Apply exclude/include
     exclude_lower = {e.lower() for e in exclude}
-    packages = [p for p in packages if p.lower() not in exclude_lower]
-
-    for inc in include:
-        if inc not in packages:
-            packages.append(inc)
-
-    return sorted(set(packages))
+    return sorted({p for p in packages if p.lower() not in exclude_lower})
 
 
 def _get_local_modules(project_dir: Path) -> set[str]:

--- a/src/coil/scanner.py
+++ b/src/coil/scanner.py
@@ -11,6 +11,37 @@ def find_py_files(project_dir: Path) -> list[Path]:
     return sorted(project_dir.rglob("*.py"))
 
 
+_DYNAMIC_IMPORT_CALLEES = {"import_module", "__import__"}
+
+
+def _dynamic_import_literal(node: ast.Call) -> str | None:
+    """Return the first positional arg of a dynamic-import call if it's a string literal.
+
+    Matches:
+    - ``importlib.import_module("x")``
+    - ``import_module("x")`` (when ``from importlib import import_module`` is in scope)
+    - ``__import__("x")``
+
+    Non-literal first args (variables, expressions) return None.
+    """
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        if func.attr != "import_module":
+            return None
+    elif isinstance(func, ast.Name):
+        if func.id not in _DYNAMIC_IMPORT_CALLEES:
+            return None
+    else:
+        return None
+
+    if not node.args:
+        return None
+    first = node.args[0]
+    if isinstance(first, ast.Constant) and isinstance(first.value, str):
+        return first.value
+    return None
+
+
 def extract_imports(source: str) -> set[str]:
     """Extract top-level module names from Python source code using AST.
 
@@ -18,6 +49,12 @@ def extract_imports(source: str) -> set[str]:
     - ``import os.path`` returns ``os``
     - ``from collections.abc import Mapping`` returns ``collections``
     - ``import numpy`` returns ``numpy``
+
+    Also detects dynamic imports with a string literal argument:
+    - ``importlib.import_module("win32pipe")`` returns ``win32pipe``
+    - ``__import__("win32file")`` returns ``win32file``
+
+    Dynamic imports with non-literal arguments are skipped silently.
     """
     try:
         tree = ast.parse(source)
@@ -34,6 +71,12 @@ def extract_imports(source: str) -> set[str]:
             if node.module is not None and node.level == 0:
                 root = node.module.split(".")[0]
                 modules.add(root)
+        elif isinstance(node, ast.Call):
+            literal = _dynamic_import_literal(node)
+            if literal:
+                root = literal.split(".")[0]
+                if root:
+                    modules.add(root)
 
     return modules
 

--- a/src/coil/utils/package_map.py
+++ b/src/coil/utils/package_map.py
@@ -1,10 +1,18 @@
-"""Mapping of Python import names to PyPI package names.
+"""Fallback mapping of Python import names to PyPI distribution names.
 
-Many packages have import names that differ from their PyPI distribution name.
-This module maintains a mapping for common cases.
+The canonical source of import→distribution mapping is
+``importlib.metadata.packages_distributions()``, which introspects the Python
+environment Coil is running in. This module is consulted **only** when that
+mapping has no entry for a given top-level module — typically the fresh-clone
+case where the dependency hasn't been installed in Coil's env yet.
+
+Keeping this list lean is deliberate: the more the hand-map covers, the more
+likely it drifts out of sync with upstream package renames. The distributions
+we carry entries for are ones where the "fresh clone before install" failure
+mode is common enough to be worth guarding.
 """
 
-# Import name -> PyPI package name
+# Import name -> PyPI distribution name
 IMPORT_TO_PYPI: dict[str, str] = {
     "PIL": "Pillow",
     "cv2": "opencv-python",
@@ -29,9 +37,19 @@ IMPORT_TO_PYPI: dict[str, str] = {
     "Crypto": "pycryptodome",
     "OpenSSL": "pyOpenSSL",
     "psutil": "psutil",
-    "win32com": "pywin32",
+    # pywin32 ships many top-level modules; cover the common ones so that a
+    # fresh clone without pywin32 installed still resolves them to a single
+    # distribution instead of trying to pip-install nonexistent packages.
     "win32api": "pywin32",
+    "win32com": "pywin32",
+    "win32con": "pywin32",
+    "win32event": "pywin32",
+    "win32file": "pywin32",
     "win32gui": "pywin32",
+    "win32job": "pywin32",
+    "win32pipe": "pywin32",
+    "win32process": "pywin32",
+    "win32service": "pywin32",
     "pythoncom": "pywin32",
     "pywintypes": "pywin32",
     "googleapiclient": "google-api-python-client",
@@ -54,9 +72,13 @@ IMPORT_TO_PYPI: dict[str, str] = {
 
 
 def resolve_package_name(import_name: str) -> str:
-    """Resolve a Python import name to its PyPI package name.
+    """Resolve a Python import name to its PyPI distribution name via the fallback map.
 
-    If the import name is in the known mapping, returns the PyPI name.
-    Otherwise, assumes the import name matches the package name.
+    If the import name is in the hand-maintained mapping, returns the PyPI
+    name. Otherwise, assumes the distribution name matches the import name.
+
+    Prefer ``importlib.metadata.packages_distributions()`` for accurate
+    resolution — this function is a fallback used by the resolver only when
+    that metadata lookup has no entry for the module.
     """
     return IMPORT_TO_PYPI.get(import_name, import_name)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -3,10 +3,13 @@
 import textwrap
 from pathlib import Path
 
+import pytest
+
 from coil.resolver import (
     parse_requirements_txt,
     parse_pyproject_toml,
     resolve_dependencies,
+    resolve_from_imports,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures" / "sample_project"
@@ -117,10 +120,14 @@ def test_resolve_package_name_mapping(tmp_path: Path):
     main = tmp_path / "main.py"
     main.write_text("from PIL import Image\nimport cv2\nimport bs4\n")
 
-    result = resolve_dependencies(tmp_path, "3.12")
-    assert "Pillow" in result
-    assert "opencv-python" in result
-    assert "beautifulsoup4" in result
+    # packages_distributions() returns the canonical distribution name from
+    # installed metadata, which may be case-normalized (e.g. 'pillow' on newer
+    # Pillow releases). pip treats distribution names case-insensitively, so
+    # match case-insensitively.
+    result_lower = {p.lower() for p in resolve_dependencies(tmp_path, "3.12")}
+    assert "pillow" in result_lower
+    assert "opencv-python" in result_lower
+    assert "beautifulsoup4" in result_lower
 
 
 def test_resolve_ignores_local_modules(tmp_path: Path):
@@ -132,3 +139,250 @@ def test_resolve_ignores_local_modules(tmp_path: Path):
     result = resolve_dependencies(tmp_path, "3.12")
     assert "requests" in result
     assert "myutil" not in result
+
+
+# ---------------------------------------------------------------------------
+# resolve_from_imports — driven by a fake dist_map so tests don't depend on
+# what happens to be installed in the CI env.
+# ---------------------------------------------------------------------------
+
+
+FAKE_DIST_MAP: dict[str, list[str]] = {
+    "psutil": ["psutil"],
+    "pypdf": ["pypdf"],
+    "PIL": ["Pillow"],
+    "PyQt5": ["PyQt5"],
+    "windows_toasts": ["windows-toasts"],
+    "win32api": ["pywin32"],
+    "win32com": ["pywin32"],
+    "win32file": ["pywin32"],
+    "win32pipe": ["pywin32"],
+    "pywintypes": ["pywin32"],
+    "requests": ["requests"],
+}
+
+
+def test_resolve_from_imports_module_equals_distribution(tmp_path: Path):
+    (tmp_path / "app.py").write_text("import psutil\nimport pypdf\n")
+    result = resolve_from_imports(tmp_path, "3.12", dist_map=FAKE_DIST_MAP)
+    assert result == ["psutil", "pypdf"]
+
+
+def test_resolve_from_imports_from_dotted_resolves_top_level(tmp_path: Path):
+    (tmp_path / "app.py").write_text("from PyQt5.QtWidgets import QApplication\n")
+    result = resolve_from_imports(tmp_path, "3.12", dist_map=FAKE_DIST_MAP)
+    assert result == ["PyQt5"]
+
+
+def test_resolve_from_imports_hyphen_underscore_distribution(tmp_path: Path):
+    (tmp_path / "app.py").write_text("from windows_toasts import InteractableWindowsToaster\n")
+    result = resolve_from_imports(tmp_path, "3.12", dist_map=FAKE_DIST_MAP)
+    assert result == ["windows-toasts"]
+
+
+def test_resolve_from_imports_distribution_differs_from_module(tmp_path: Path):
+    (tmp_path / "app.py").write_text("from PIL import Image\n")
+    result = resolve_from_imports(tmp_path, "3.12", dist_map=FAKE_DIST_MAP)
+    assert result == ["Pillow"]
+
+
+def test_resolve_from_imports_multi_top_level_dedupes(tmp_path: Path):
+    (tmp_path / "app.py").write_text(
+        "import win32api\n"
+        "import win32file\n"
+        "from win32com.client import Dispatch\n"
+        "import pywintypes\n"
+    )
+    result = resolve_from_imports(tmp_path, "3.12", dist_map=FAKE_DIST_MAP)
+    assert result == ["pywin32"]
+
+
+def test_resolve_from_imports_skips_stdlib(tmp_path: Path):
+    (tmp_path / "app.py").write_text(
+        "import os\n"
+        "import sys\n"
+        "import pathlib\n"
+        "import importlib\n"
+    )
+    result = resolve_from_imports(tmp_path, "3.12", dist_map=FAKE_DIST_MAP)
+    assert result == []
+
+
+def test_resolve_from_imports_dynamic_literal_resolves(tmp_path: Path):
+    # The explicit bridge that retires the downstream
+    # `win32pipe = importlib.import_module('win32pipe')` workaround.
+    (tmp_path / "app.py").write_text(
+        "import importlib\n"
+        "win32pipe = importlib.import_module('win32pipe')\n"
+    )
+    result = resolve_from_imports(tmp_path, "3.12", dist_map=FAKE_DIST_MAP)
+    assert result == ["pywin32"]
+
+
+def test_resolve_from_imports_dunder_import_literal_resolves(tmp_path: Path):
+    (tmp_path / "app.py").write_text('mod = __import__("win32pipe")\n')
+    result = resolve_from_imports(tmp_path, "3.12", dist_map=FAKE_DIST_MAP)
+    assert result == ["pywin32"]
+
+
+def test_resolve_from_imports_dynamic_non_literal_skipped(tmp_path: Path):
+    # Non-literal arg — can't be resolved statically, must be skipped silently.
+    (tmp_path / "app.py").write_text(
+        "import importlib\n"
+        "name = some_runtime_value()\n"
+        "mod = importlib.import_module(name)\n"
+    )
+    result = resolve_from_imports(tmp_path, "3.12", dist_map=FAKE_DIST_MAP)
+    assert result == []
+
+
+def test_resolve_from_imports_multi_dist_picks_first_and_warns(tmp_path: Path):
+    (tmp_path / "app.py").write_text("import shared\n")
+    dist_map = {"shared": ["alpha-pkg", "zeta-pkg"]}
+    warnings: list[str] = []
+    result = resolve_from_imports(
+        tmp_path, "3.12", dist_map=dist_map, warn=warnings.append
+    )
+    assert result == ["alpha-pkg"]
+    assert len(warnings) == 1
+    assert "shared" in warnings[0]
+    assert "alpha-pkg" in warnings[0]
+    assert "zeta-pkg" in warnings[0]
+
+
+def test_resolve_from_imports_fallback_to_hand_map(tmp_path: Path):
+    # Empty dist_map simulates the fresh-clone case where the dep isn't yet
+    # installed in Coil's own env. IMPORT_TO_PYPI should kick in.
+    (tmp_path / "app.py").write_text("from PIL import Image\nimport win32file\n")
+    result = resolve_from_imports(tmp_path, "3.12", dist_map={})
+    assert "Pillow" in result
+    assert "pywin32" in result
+    # win32file should NOT leak through as a standalone distribution — that's
+    # the false-positive bug this whole change is about.
+    assert "win32file" not in result
+
+
+def test_resolve_dependencies_auto_unions_with_project_dependencies(tmp_path: Path):
+    # Additive semantics: [project].dependencies keeps its version pins AND
+    # auto-detected imports are added on top.
+    (tmp_path / "pyproject.toml").write_text(textwrap.dedent("""\
+        [project]
+        name = "app"
+        dependencies = ["pinned-lib>=1.0"]
+    """))
+    (tmp_path / "app.py").write_text("import psutil\n")
+    result = resolve_dependencies(
+        tmp_path, "3.12", auto=True, dist_map=FAKE_DIST_MAP
+    )
+    assert "pinned-lib" in result
+    assert "psutil" in result
+
+
+def test_resolve_dependencies_auto_false_skips_import_scan(tmp_path: Path):
+    (tmp_path / "pyproject.toml").write_text(textwrap.dedent("""\
+        [project]
+        name = "app"
+        dependencies = ["pinned-lib"]
+    """))
+    (tmp_path / "app.py").write_text("import psutil\n")
+    result = resolve_dependencies(
+        tmp_path, "3.12", auto=False, dist_map=FAKE_DIST_MAP
+    )
+    assert result == ["pinned-lib"]
+
+
+def test_resolve_dependencies_include_unions_with_auto(tmp_path: Path):
+    (tmp_path / "app.py").write_text("import psutil\n")
+    result = resolve_dependencies(
+        tmp_path,
+        "3.12",
+        auto=True,
+        dist_map=FAKE_DIST_MAP,
+        include=["extra-manual"],
+    )
+    assert "psutil" in result
+    assert "extra-manual" in result
+
+
+def test_resolve_dependencies_exclude_applies_last(tmp_path: Path):
+    (tmp_path / "pyproject.toml").write_text(textwrap.dedent("""\
+        [project]
+        name = "app"
+        dependencies = ["pinned-lib"]
+    """))
+    (tmp_path / "app.py").write_text("import psutil\n")
+    result = resolve_dependencies(
+        tmp_path,
+        "3.12",
+        auto=True,
+        dist_map=FAKE_DIST_MAP,
+        include=["extra-manual"],
+        exclude=["psutil", "extra-manual"],
+    )
+    assert "pinned-lib" in result
+    assert "psutil" not in result
+    assert "extra-manual" not in result
+
+
+def test_resolve_dependencies_warn_invoked_on_multi_dist(tmp_path: Path):
+    (tmp_path / "app.py").write_text("import shared\n")
+    warnings: list[str] = []
+    resolve_dependencies(
+        tmp_path,
+        "3.12",
+        auto=True,
+        dist_map={"shared": ["alpha-pkg", "zeta-pkg"]},
+        warn=warnings.append,
+    )
+    assert any("shared" in w for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# Integration: run against the real env's packages_distributions(), but skip
+# any assertion whose package isn't installed so CI stays green.
+# ---------------------------------------------------------------------------
+
+
+def _has_distribution(name: str) -> bool:
+    import importlib.metadata
+    try:
+        importlib.metadata.distribution(name)
+        return True
+    except importlib.metadata.PackageNotFoundError:
+        return False
+
+
+def test_resolve_from_imports_integration_real_env(tmp_path: Path):
+    (tmp_path / "app.py").write_text(textwrap.dedent("""\
+        from PIL import Image
+        from PyQt5.QtWidgets import QApplication
+        from windows_toasts import InteractableWindowsToaster
+        import win32api
+        import win32file
+        from win32com.client import Dispatch
+        import pywintypes
+    """))
+
+    result = resolve_from_imports(tmp_path, "3.12")
+    result_lower = {p.lower() for p in result}
+
+    # pip treats distribution names case-insensitively, so assert on lowercase.
+    expectations = ("pillow", "pyqt5", "windows-toasts", "pywin32")
+    checked = False
+    for dist in expectations:
+        if not _has_distribution(dist):
+            continue
+        checked = True
+        assert dist in result_lower, (
+            f"expected {dist!r} in resolver output, got {result!r}"
+        )
+
+    if not checked:
+        pytest.skip(
+            "none of Pillow/PyQt5/windows-toasts/pywin32 installed; skipping"
+        )
+
+    # Regardless of what's installed, the false-positive bug must stay fixed:
+    # win32file/win32pipe/win32api must never appear as standalone distributions.
+    for false_positive in ("win32file", "win32pipe", "win32api", "pywintypes"):
+        assert false_positive not in result_lower

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -43,6 +43,50 @@ def test_extract_imports_syntax_error():
     assert result == set()
 
 
+def test_extract_imports_importlib_literal():
+    source = (
+        "import importlib\n"
+        "win32pipe = importlib.import_module('win32pipe')\n"
+    )
+    result = extract_imports(source)
+    assert "win32pipe" in result
+
+
+def test_extract_imports_importlib_aliased():
+    source = (
+        "from importlib import import_module\n"
+        "mod = import_module('pywintypes')\n"
+    )
+    result = extract_imports(source)
+    assert "pywintypes" in result
+
+
+def test_extract_imports_dunder_import_literal():
+    source = "mod = __import__('win32file')\n"
+    result = extract_imports(source)
+    assert "win32file" in result
+
+
+def test_extract_imports_dynamic_non_literal_skipped():
+    source = (
+        "import importlib\n"
+        "name = get_name()\n"
+        "mod = importlib.import_module(name)\n"
+    )
+    result = extract_imports(source)
+    assert "importlib" in result  # the plain import is still picked up
+    # But no spurious module should be added from the dynamic call.
+    assert result == {"importlib"}
+
+
+def test_extract_imports_importlib_dotted_literal():
+    source = "import importlib\nm = importlib.import_module('a.b.c')\n"
+    result = extract_imports(source)
+    assert "a" in result
+    assert "b" not in result
+    assert "c" not in result
+
+
 def test_extract_imports_deep_in_file():
     source = (
         "x = 1\n" * 100


### PR DESCRIPTION
## Summary

Replaces the hand-maintained `IMPORT_TO_PYPI` dict with `importlib.metadata.packages_distributions()` as the primary import→distribution resolver. The hand map stays as a fallback for fresh-clone builds (before deps are installed in Coil's own env).

Fixes both sides of the resolver bug:

- **False positives** — `import win32file` / `win32pipe` / `win32job` / `win32con` no longer get treated as standalone PyPI distributions. `packages_distributions()` returns `pywin32` for all of them; the extended fallback map covers the common submodules for fresh clones. Retires the downstream `win32pipe = importlib.import_module('win32pipe')` workaround.
- **False negatives** — `pyproject.toml` presence no longer short-circuits auto-detection. `auto = true` is now load-bearing and **additive**: import-detected deps union with `[project].dependencies` + `include`, so version pins are preserved. `pystray`, `psutil`, `pypdf`, `clipboard`, `windows-toasts`, `PyQt5`, etc. all resolve without being hand-listed in `include`.

## Behavior changes

- `[build.dependencies] auto = true` (previously decorative) now triggers import-based auto-detection that unions with `[project].dependencies` and `include`. Default is `True` to match existing config-file semantics.
- `exclude = [...]` still applies as the last step, unchanged.
- Explicit `--requirements` and `requirements.txt` escape hatches still work and still union `include`.
- Scanner now detects `importlib.import_module("literal")` / `__import__("literal")`. Non-literal args are skipped silently.
- When one top-level module is provided by multiple distributions (rare), the resolver picks the first in sorted order and emits a one-line warning via `BuildUI.warning`.

## Test plan

- [x] New unit tests in `tests/test_resolver.py` covering: module==dist, `from X.Y import Z` resolves `X`, hyphen/underscore names (`windows-toasts` / `windows_toasts`), Pillow/PIL, pywin32 multi-top-level dedupe, stdlib skip, `importlib.import_module("literal")` bridge, `__import__("literal")` bridge, non-literal arg skipped, multi-dist deterministic + warning, include/exclude union/trim semantics, fallback-to-hand-map for fresh-clone case.
- [x] New scanner tests in `tests/test_scanner.py` for the three dynamic-import forms + dotted-literal + non-literal skipping.
- [x] Integration test against real `packages_distributions()`: imports `PIL`, `PyQt5`, `windows_toasts`, `win32api`/`win32file`/`win32com`/`pywintypes`; asserts they resolve to the correct distributions (skipping per-package when not installed). Asserts `win32file`/`win32pipe`/`win32api`/`pywintypes` never appear as standalone distributions.
- [x] Full test suite passes (237 tests). 9 pre-existing `test_packager.py` failures reproduce on `master` unchanged (cross-arch Python subprocess — `WinError 216`); out of scope for this PR.

## Non-goals

No changes to VERSIONINFO, launcher, PE subsystem, or `.pth` handling — those are separate PRs in flight.