### PR TITLE
Per-entry PE subsystem in coil.toml

### DIFF
--- a/src/coil/builder.py
+++ b/src/coil/builder.py
@@ -47,6 +47,7 @@ def build(
     clean: bool = False,
     optimize: int | None = None,
     versioninfo: dict[str, dict[str, str]] | None = None,
+    subsystems: dict[str, str] | None = None,
     deps_auto: bool = True,
 ) -> list[Path]:
     """Execute the full build pipeline.
@@ -69,6 +70,9 @@ def build(
         clean: Build in a clean environment with only declared dependencies.
         optimize: Bytecode optimization level (0, 1, 2). None = auto.
         versioninfo: Resolved per-entry VERSIONINFO fields, keyed by entry stem.
+        subsystems: Explicit per-entry PE subsystem overrides, keyed by
+            entry stem. Values are "gui" or "console". Entries without an
+            override fall through to the existing hybrid default.
         deps_auto: When True, auto-detect imports and union with declared
             dependencies. Reflects [build.dependencies].auto in coil.toml.
 
@@ -175,6 +179,7 @@ def build(
                 ui=ui,
                 optimize=optimize,
                 versioninfo=versioninfo,
+                subsystems=subsystems,
             )
             outputs = [result]
         else:
@@ -193,6 +198,7 @@ def build(
                 ui=ui,
                 optimize=optimize,
                 versioninfo=versioninfo,
+                subsystems=subsystems,
             )
 
     ui.build_summary(outputs)

--- a/src/coil/cli.py
+++ b/src/coil/cli.py
@@ -642,8 +642,12 @@ def main(argv: list[str] | None = None) -> None:
 
         # Resolve per-entry VERSIONINFO from coil.toml if present.
         versioninfo: dict[str, dict[str, str]] | None = None
+        subsystems: dict[str, str] | None = None
         deps_auto = True
-        from coil.config import load_config, get_build_config, get_versioninfo_config
+        from coil.config import (
+            load_config, get_build_config, get_versioninfo_config,
+            get_subsystem_config,
+        )
         raw_toml = load_config(project_dir)
         if raw_toml is not None:
             try:
@@ -652,6 +656,7 @@ def main(argv: list[str] | None = None) -> None:
             except ValueError:
                 pass
             versioninfo = {}
+            subsystems = {}
             for ep in entry_points:
                 stem = Path(ep).stem
                 versioninfo[stem] = get_versioninfo_config(
@@ -660,6 +665,13 @@ def main(argv: list[str] | None = None) -> None:
                     project_name=name,
                     project_dir=project_dir,
                 )
+                try:
+                    sub = get_subsystem_config(raw_toml, entry_name=stem)
+                except ValueError as e:
+                    print(f"Error: {e}")
+                    sys.exit(1)
+                if sub is not None:
+                    subsystems[stem] = sub
             # For single-entry builds, the exe is named `name`, not the
             # source stem. Duplicate the entry under that key so the
             # packager finds it.
@@ -667,6 +679,8 @@ def main(argv: list[str] | None = None) -> None:
                 only_stem = Path(entry_points[0]).stem
                 if name and name != only_stem:
                     versioninfo[name] = versioninfo[only_stem]
+                    if only_stem in subsystems:
+                        subsystems[name] = subsystems[only_stem]
 
         try:
             from coil.builder import build
@@ -688,6 +702,7 @@ def main(argv: list[str] | None = None) -> None:
                 clean=args.clean,
                 optimize=optimize,
                 versioninfo=versioninfo,
+                subsystems=subsystems,
                 deps_auto=deps_auto,
             )
         except Exception as e:

--- a/src/coil/config.py
+++ b/src/coil/config.py
@@ -145,6 +145,39 @@ def get_versioninfo_config(
     }
 
 
+def get_subsystem_config(raw: dict[str, Any], entry_name: str) -> Optional[str]:
+    """Resolve the explicit PE subsystem for a single entry.
+
+    Reads [build.entries.<stem>].subsystem. Returns "gui" or "console" when
+    set, None when absent (callers fall through to the existing hybrid
+    default: top-level --gui flag for the primary entry, per-file GUI-import
+    autodetect for extras).
+
+    Args:
+        raw: Parsed coil.toml.
+        entry_name: Entry point stem (e.g. "main" for "main.py").
+
+    Returns:
+        "gui", "console", or None.
+
+    Raises:
+        ValueError: If the configured value is not "gui" or "console".
+    """
+    build = raw.get("build", {})
+    entries = build.get("entries", {}) or {}
+    per_entry = entries.get(entry_name, {}) or {}
+    value = per_entry.get("subsystem")
+
+    if value is None:
+        return None
+    if value not in ("gui", "console"):
+        raise ValueError(
+            f"Invalid subsystem for entry {entry_name!r}: "
+            f"expected 'console' or 'gui', got {value!r}"
+        )
+    return value
+
+
 def get_build_config(
     raw: dict[str, Any],
     profile: Optional[str] = None,

--- a/src/coil/packager.py
+++ b/src/coil/packager.py
@@ -35,6 +35,24 @@ _EXE_DLLS = {
 }
 
 
+def _lookup_subsystem(
+    subsystems: Optional[dict[str, str]],
+    *keys: str,
+) -> Optional[str]:
+    """Pick the explicit subsystem for the first matching key, or None.
+
+    The CLI stores subsystem overrides under the entry stem and, for
+    single-entry builds renamed via --name, also under the final exe name.
+    Try both.
+    """
+    if not subsystems:
+        return None
+    for key in keys:
+        if key in subsystems:
+            return subsystems[key]
+    return None
+
+
 def package_portable(
     project_dir: Path,
     output_dir: Path,
@@ -50,6 +68,7 @@ def package_portable(
     ui: Optional[BuildUI] = None,
     optimize: Optional[int] = None,
     versioninfo: Optional[dict[str, dict[str, str]]] = None,
+    subsystems: Optional[dict[str, str]] = None,
 ) -> list[Path]:
     """Create a portable build: single self-contained .exe per entry point.
 
@@ -78,6 +97,8 @@ def package_portable(
 
     for entry in entry_points:
         entry_name = Path(entry).stem if len(entry_points) > 1 else name
+        entry_stem = Path(entry).stem
+        explicit_sub = _lookup_subsystem(subsystems, entry_stem, entry_name)
 
         if ui is not None:
             ui.detail(f"Packaging portable exe for {entry}")
@@ -100,6 +121,7 @@ def package_portable(
                 verbose=verbose,
                 ui=ui,
                 optimize=optimize,
+                subsystem=explicit_sub,
             )
 
             # Step 2: Zip the staged directory
@@ -127,7 +149,7 @@ def package_portable(
 
         vi_fields = (versioninfo or {}).get(entry_name)
 
-        if sys.platform == "win32" and (icon or vi_fields):
+        if sys.platform == "win32" and (icon or vi_fields or explicit_sub is not None):
             with tempfile.NamedTemporaryFile(suffix=".exe", delete=False) as tf:
                 tf.write(bootloader_stub)
                 stub_path = Path(tf.name)
@@ -155,6 +177,21 @@ def package_portable(
                             ui.warning(f"Could not set version info: {e}")
                         elif verbose:
                             print(f"  Warning: Could not set version info: {e}")
+
+                if explicit_sub is not None:
+                    from coil.platforms.windows import set_pe_subsystem
+                    try:
+                        set_pe_subsystem(stub_path, explicit_sub)
+                        if ui is not None:
+                            ui.detail(
+                                f"Subsystem {explicit_sub!r} applied to entry "
+                                f"{entry_stem!r} (explicit override)"
+                            )
+                    except Exception as e:
+                        if ui is not None:
+                            ui.warning(f"Could not set subsystem: {e}")
+                        elif verbose:
+                            print(f"  Warning: Could not set subsystem: {e}")
 
                 stub = stub_path.read_bytes()
             finally:
@@ -197,6 +234,7 @@ def package_bundled(
     ui: Optional[BuildUI] = None,
     optimize: Optional[int] = None,
     versioninfo: Optional[dict[str, dict[str, str]]] = None,
+    subsystems: Optional[dict[str, str]] = None,
 ) -> Path:
     """Create a bundled build: directory with exe and supporting files.
 
@@ -235,6 +273,7 @@ def package_bundled(
     # for single-entry (which may differ from the source filename via --name).
     primary_vi_key = Path(entry).stem if len(entry_points) > 1 else entry_name
     primary_vi = (versioninfo or {}).get(primary_vi_key)
+    primary_sub = _lookup_subsystem(subsystems, Path(entry).stem, entry_name)
     _build_app_directory(
         project_dir=project_dir,
         stage_dir=bundle_dir,
@@ -249,6 +288,7 @@ def package_bundled(
         ui=ui,
         optimize=optimize,
         versioninfo=primary_vi,
+        subsystem=primary_sub,
     )
 
     # For multiple entry points, create additional launchers
@@ -257,9 +297,15 @@ def package_bundled(
             extra_name = Path(extra_entry).stem
             extra_pyc = extra_entry.replace(".py", ".pyc")
 
-            # Per-entry GUI detection
+            # Explicit subsystem config wins over GUI-import autodetect.
+            extra_sub = _lookup_subsystem(subsystems, extra_name, extra_name)
             extra_file = project_dir / extra_entry
-            extra_gui = file_has_gui_imports(extra_file) if extra_file.is_file() else gui
+            if extra_sub is not None:
+                extra_gui = (extra_sub == "gui")
+            else:
+                extra_gui = (
+                    file_has_gui_imports(extra_file) if extra_file.is_file() else gui
+                )
 
             # Copy python exe as the extra entry
             source_exe_name = "pythonw.exe" if extra_gui else "python.exe"
@@ -292,6 +338,19 @@ def package_bundled(
                 except Exception:
                     pass
 
+                if extra_sub is not None and extra_exe.is_file():
+                    from coil.platforms.windows import set_pe_subsystem
+                    try:
+                        set_pe_subsystem(extra_exe, extra_sub)
+                        if ui is not None:
+                            ui.detail(
+                                f"Subsystem {extra_sub!r} applied to entry "
+                                f"{extra_name!r} (explicit override)"
+                            )
+                    except Exception as e:
+                        if ui is not None:
+                            ui.warning(f"Could not set subsystem: {e}")
+
             if ui is not None:
                 ui.detail(f"Created launcher for {extra_entry}")
             elif verbose:
@@ -319,6 +378,7 @@ def _build_app_directory(
     ui: Optional[BuildUI] = None,
     optimize: Optional[int] = None,
     versioninfo: Optional[dict[str, str]] = None,
+    subsystem: Optional[str] = None,
 ) -> None:
     """Build the full application directory structure.
 
@@ -376,8 +436,13 @@ def _build_app_directory(
     project_imports = scan_project(project_dir)
     _strip_stdlib_zip(internal_dir, project_imports, ui=ui, verbose=verbose)
 
-    # Copy the right python exe as AppName.exe
-    source_exe_name = "pythonw.exe" if gui else "python.exe"
+    # Copy the right python exe as AppName.exe. Explicit subsystem (from
+    # [build.entries.<stem>].subsystem) wins over the top-level gui flag.
+    if subsystem is not None:
+        use_gui = (subsystem == "gui")
+    else:
+        use_gui = gui
+    source_exe_name = "pythonw.exe" if use_gui else "python.exe"
     source_exe = runtime_dir / source_exe_name
     target_exe = stage_dir / f"{entry_name}.exe"
     if source_exe.is_file():
@@ -419,13 +484,26 @@ def _build_app_directory(
     # Configure ._pth and sitecustomize.py
     _configure_pth(stage_dir, internal_dir, entry_name, ver_tag)
 
-    # Set GUI subsystem if needed
-    if gui and target_exe.is_file():
+    # Stamp subsystem. Explicit config wins; otherwise fall through to the
+    # top-level gui flag (preserves existing behavior).
+    if target_exe.is_file() and sys.platform == "win32":
         from coil.platforms.windows import set_pe_subsystem
-        try:
-            set_pe_subsystem(target_exe, gui=True)
-        except Exception:
-            pass
+        if subsystem is not None:
+            try:
+                set_pe_subsystem(target_exe, subsystem)
+                if ui is not None:
+                    ui.detail(
+                        f"Subsystem {subsystem!r} applied to entry "
+                        f"{entry_name!r} (explicit override)"
+                    )
+            except Exception as e:
+                if ui is not None:
+                    ui.warning(f"Could not set subsystem: {e}")
+        elif gui:
+            try:
+                set_pe_subsystem(target_exe, True)
+            except Exception:
+                pass
 
     # Apply icon to the inner exe
     if icon and target_exe.is_file() and sys.platform == "win32":

--- a/src/coil/platforms/windows.py
+++ b/src/coil/platforms/windows.py
@@ -472,24 +472,35 @@ def set_version_info(
         raise
 
 
-def set_pe_subsystem(exe_path: Path, gui: bool) -> None:
+def set_pe_subsystem(exe_path: Path, subsystem: "bool | str") -> None:
     """Modify a PE executable's subsystem flag.
 
-    Sets the subsystem to GUI (2) or Console (3) in the PE header.
-    This is used to prevent a console window from appearing for GUI apps.
+    Sets the subsystem to GUI (2) or Console (3) in the PE header. The
+    subsystem WORD lives at pe_offset + 0x5C (4-byte PE sig + 20-byte
+    COFF header + 68 into the optional header), identical for PE32 and
+    PE32+.
 
     Args:
         exe_path: Path to the .exe file.
-        gui: True for GUI subsystem, False for console.
+        subsystem: Either a bool (True = GUI, False = Console) or one of
+            the strings "gui" / "console".
+
+    Raises:
+        ValueError: If subsystem is a string other than "gui" or "console".
     """
-    subsystem = _PE_GUI_SUBSYSTEM if gui else _PE_CONSOLE_SUBSYSTEM
+    if isinstance(subsystem, str):
+        if subsystem not in ("gui", "console"):
+            raise ValueError(
+                f"Invalid subsystem {subsystem!r}: expected 'gui' or 'console'"
+            )
+        subsystem_value = _PE_GUI_SUBSYSTEM if subsystem == "gui" else _PE_CONSOLE_SUBSYSTEM
+    else:
+        subsystem_value = _PE_GUI_SUBSYSTEM if subsystem else _PE_CONSOLE_SUBSYSTEM
 
     with open(exe_path, "r+b") as f:
-        # Read DOS header to find PE offset
         f.seek(0x3C)
         pe_offset = struct.unpack("<I", f.read(4))[0]
 
-        # PE subsystem is at PE offset + 0x5C
         subsystem_offset = pe_offset + 0x5C
         f.seek(subsystem_offset)
-        f.write(struct.pack("<H", subsystem))
+        f.write(struct.pack("<H", subsystem_value))

--- a/tests/fixtures/subsystem_sample/coil.toml
+++ b/tests/fixtures/subsystem_sample/coil.toml
@@ -1,0 +1,21 @@
+[project]
+name = "SubsystemSample"
+version = "1.0.0"
+
+[build]
+mode = "bundled"
+os = "windows"
+
+# main: no [build.entries.main] block — falls through to the default
+# hybrid (top-level gui flag + file_has_gui_imports autodetect).
+#
+# gui_entry: explicit GUI subsystem — overrides any autodetect.
+# console_entry: explicit Console subsystem — even though the file has
+# no GUI imports, the explicit override is what gets stamped. Used to
+# prove the override path runs end-to-end.
+
+[build.entries.gui_entry]
+subsystem = "gui"
+
+[build.entries.console_entry]
+subsystem = "console"

--- a/tests/fixtures/subsystem_sample/console_entry.py
+++ b/tests/fixtures/subsystem_sample/console_entry.py
@@ -1,0 +1,1 @@
+print("console_entry")

--- a/tests/fixtures/subsystem_sample/gui_entry.py
+++ b/tests/fixtures/subsystem_sample/gui_entry.py
@@ -1,0 +1,1 @@
+print("gui_entry")

--- a/tests/fixtures/subsystem_sample/main.py
+++ b/tests/fixtures/subsystem_sample/main.py
@@ -1,0 +1,1 @@
+print("main")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from coil.config import (
     get_build_config,
     generate_toml,
     get_versioninfo_config,
+    get_subsystem_config,
     _pad_version,
     _resolve_project_version,
 )
@@ -365,3 +366,59 @@ def test_roundtrip_generate_then_load(tmp_path: Path):
     assert config["python"] == "3.12"
     assert config["icon"] == "test.ico"
     assert config["mode"] == "portable"
+
+
+def test_subsystem_absent_returns_none():
+    """No [build.entries] config at all — resolver returns None."""
+    raw = {"project": {"name": "X"}, "build": {}}
+    assert get_subsystem_config(raw, "main") is None
+
+
+def test_subsystem_entry_missing_returns_none():
+    """Other entries have config but this one doesn't — returns None."""
+    raw = {"build": {"entries": {"worker": {"subsystem": "console"}}}}
+    assert get_subsystem_config(raw, "main") is None
+
+
+def test_subsystem_explicit_console_returned():
+    raw = {"build": {"entries": {"update_checker": {"subsystem": "console"}}}}
+    assert get_subsystem_config(raw, "update_checker") == "console"
+
+
+def test_subsystem_explicit_gui_returned():
+    raw = {"build": {"entries": {"main": {"subsystem": "gui"}}}}
+    assert get_subsystem_config(raw, "main") == "gui"
+
+
+def test_subsystem_invalid_value_raises():
+    raw = {"build": {"entries": {"helper": {"subsystem": "neither"}}}}
+    with pytest.raises(ValueError) as exc:
+        get_subsystem_config(raw, "helper")
+    # Error message names the entry and the bad value.
+    assert "helper" in str(exc.value)
+    assert "neither" in str(exc.value)
+
+
+def test_subsystem_empty_string_raises():
+    raw = {"build": {"entries": {"helper": {"subsystem": ""}}}}
+    with pytest.raises(ValueError):
+        get_subsystem_config(raw, "helper")
+
+
+def test_subsystem_load_from_toml(tmp_path: Path):
+    """Full round-trip: write toml, load, resolve per entry."""
+    (tmp_path / "coil.toml").write_text(
+        '[project]\n'
+        'entry = ["MyApp.py", "update_checker.py"]\n'
+        'name = "MyApp"\n'
+        '\n'
+        '[build]\n'
+        'mode = "bundled"\n'
+        '\n'
+        '[build.entries.update_checker]\n'
+        'subsystem = "console"\n'
+    )
+    raw = load_config(tmp_path)
+    assert raw is not None
+    assert get_subsystem_config(raw, "update_checker") == "console"
+    assert get_subsystem_config(raw, "MyApp") is None

--- a/tests/test_subsystem_integration.py
+++ b/tests/test_subsystem_integration.py
@@ -1,0 +1,150 @@
+"""End-to-end: build the subsystem fixture and verify each exe's PE subsystem.
+
+Uses a real Python runtime (copied from the host interpreter) so target
+exes are stampable PEs. Parses produced exes with pefile.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32", reason="PE subsystem stamping is Windows-only"
+)
+
+pefile = pytest.importorskip("pefile")
+
+from coil.config import get_subsystem_config, load_config
+from coil.packager import package_bundled
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "subsystem_sample"
+
+
+def _make_real_runtime(tmp_path: Path) -> Path:
+    """Synthetic embeddable-like runtime using the host interpreter's files."""
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    host_dir = Path(sys.executable).parent
+
+    for exe_name in ("python.exe", "pythonw.exe"):
+        src = host_dir / exe_name
+        if src.is_file():
+            shutil.copy2(src, runtime / exe_name)
+
+    for pattern in ("python*.dll", "vcruntime*.dll"):
+        for dll in host_dir.glob(pattern):
+            shutil.copy2(dll, runtime / dll.name)
+
+    ver_tag = f"{sys.version_info.major}{sys.version_info.minor}"
+    (runtime / f"python{ver_tag}._pth").write_text(f"python{ver_tag}.zip\n.\n")
+
+    import zipfile
+    zip_path = runtime / f"python{ver_tag}.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        pass
+
+    return runtime
+
+
+def _read_subsystem(exe_path: Path) -> int:
+    pe = pefile.PE(str(exe_path), fast_load=True)
+    try:
+        return int(pe.OPTIONAL_HEADER.Subsystem)
+    finally:
+        pe.close()
+
+
+def test_bundled_build_stamps_subsystem_per_entry(tmp_path: Path, monkeypatch):
+    """Full pipeline: 3 entries with different subsystem declarations.
+
+    - main: no explicit subsystem → falls through (gui=False by default
+      → console subsystem, via the default python.exe copy path).
+    - gui_entry: explicit "gui" → GUI subsystem (2).
+    - console_entry: explicit "console" → Console subsystem (3).
+    """
+    raw = load_config(FIXTURE_DIR)
+    assert raw is not None
+
+    entries = ["main.py", "gui_entry.py", "console_entry.py"]
+    stems = [Path(e).stem for e in entries]
+
+    subsystems: dict[str, str] = {}
+    for stem in stems:
+        sub = get_subsystem_config(raw, entry_name=stem)
+        if sub is not None:
+            subsystems[stem] = sub
+
+    # Only the two explicit entries should be in the dict.
+    assert subsystems == {"gui_entry": "gui", "console_entry": "console"}
+
+    # Skip real compilation: we don't need real .pyc files.
+    def _fake_obfuscate(project_dir, internal_dir, ui=None, optimize=0, runtime_python=None):
+        app_dir = internal_dir / "app"
+        app_dir.mkdir(parents=True, exist_ok=True)
+        for src in project_dir.glob("*.py"):
+            (app_dir / (src.stem + ".pyc")).write_bytes(b"")
+
+    monkeypatch.setattr("coil.packager.obfuscate_default", _fake_obfuscate)
+    monkeypatch.setattr("coil.packager.obfuscate_secure", _fake_obfuscate)
+
+    runtime = _make_real_runtime(tmp_path)
+    output = tmp_path / "dist"
+
+    bundle = package_bundled(
+        project_dir=FIXTURE_DIR,
+        output_dir=output,
+        runtime_dir=runtime,
+        entry_points=entries,
+        name="SubsystemSample",
+        target_os="windows",
+        subsystems=subsystems,
+    )
+    assert bundle.is_dir()
+
+    # main.exe: no override; gui=False default → python.exe (Console=3)
+    assert _read_subsystem(bundle / "main.exe") == 3
+    # gui_entry.exe: explicit "gui" → GUI=2
+    assert _read_subsystem(bundle / "gui_entry.exe") == 2
+    # console_entry.exe: explicit "console" → Console=3
+    assert _read_subsystem(bundle / "console_entry.exe") == 3
+
+
+def test_bundled_build_explicit_override_beats_gui_flag(tmp_path: Path, monkeypatch):
+    """Top-level gui=True says GUI for everything, but an explicit
+    "console" override on an entry must still produce Console."""
+    entries = ["main.py", "console_entry.py"]
+
+    subsystems = {"console_entry": "console"}
+
+    def _fake_obfuscate(project_dir, internal_dir, ui=None, optimize=0, runtime_python=None):
+        app_dir = internal_dir / "app"
+        app_dir.mkdir(parents=True, exist_ok=True)
+        for src in project_dir.glob("*.py"):
+            (app_dir / (src.stem + ".pyc")).write_bytes(b"")
+
+    monkeypatch.setattr("coil.packager.obfuscate_default", _fake_obfuscate)
+    monkeypatch.setattr("coil.packager.obfuscate_secure", _fake_obfuscate)
+
+    runtime = _make_real_runtime(tmp_path)
+    output = tmp_path / "dist"
+
+    bundle = package_bundled(
+        project_dir=FIXTURE_DIR,
+        output_dir=output,
+        runtime_dir=runtime,
+        entry_points=entries,
+        name="SubsystemSample",
+        target_os="windows",
+        gui=True,
+        subsystems=subsystems,
+    )
+
+    # main.exe: no override, top-level gui=True → GUI subsystem (2)
+    assert _read_subsystem(bundle / "main.exe") == 2
+    # console_entry.exe: explicit override beats top-level gui=True → Console (3)
+    assert _read_subsystem(bundle / "console_entry.exe") == 3

--- a/tests/test_windows_subsystem.py
+++ b/tests/test_windows_subsystem.py
@@ -1,0 +1,94 @@
+"""Tests for set_pe_subsystem on Windows.
+
+Verifies the PE subsystem WORD is written correctly (GUI=2, Console=3),
+that flipping does not corrupt other PE bytes, and that invalid string
+values raise ValueError.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32", reason="PE subsystem writer is Windows-only"
+)
+
+pefile = pytest.importorskip("pefile")
+
+from coil.platforms.windows import set_pe_subsystem
+
+
+def _copy_python_exe(tmp_path: Path, name: str = "sample.exe") -> Path:
+    src = Path(sys.executable)
+    dest = tmp_path / name
+    shutil.copy2(src, dest)
+    return dest
+
+
+def _read_subsystem(exe_path: Path) -> int:
+    pe = pefile.PE(str(exe_path), fast_load=True)
+    try:
+        return int(pe.OPTIONAL_HEADER.Subsystem)
+    finally:
+        pe.close()
+
+
+def test_set_subsystem_to_console(tmp_path: Path):
+    exe = _copy_python_exe(tmp_path)
+    set_pe_subsystem(exe, "console")
+    assert _read_subsystem(exe) == 3
+
+
+def test_set_subsystem_to_gui(tmp_path: Path):
+    exe = _copy_python_exe(tmp_path)
+    set_pe_subsystem(exe, "gui")
+    assert _read_subsystem(exe) == 2
+
+
+def test_set_subsystem_bool_backwards_compatible(tmp_path: Path):
+    exe = _copy_python_exe(tmp_path)
+    set_pe_subsystem(exe, True)
+    assert _read_subsystem(exe) == 2
+    set_pe_subsystem(exe, False)
+    assert _read_subsystem(exe) == 3
+
+
+def test_flip_flop_does_not_corrupt_other_bytes(tmp_path: Path):
+    """Round-tripping console↔gui should only ever change the 2-byte subsystem WORD."""
+    exe = _copy_python_exe(tmp_path)
+    original = exe.read_bytes()
+
+    for target in ("console", "gui", "console", "gui"):
+        set_pe_subsystem(exe, target)
+
+    # End on gui; verify the file is original except for the 2-byte subsystem
+    # WORD at pe_offset + 0x5C.
+    set_pe_subsystem(exe, "gui")
+    after = exe.read_bytes()
+
+    import struct
+    pe_offset = struct.unpack_from("<I", original, 0x3C)[0]
+    subsystem_offset = pe_offset + 0x5C
+
+    # Bytes before the subsystem WORD are identical.
+    assert original[:subsystem_offset] == after[:subsystem_offset]
+    # Bytes after the subsystem WORD are identical.
+    assert original[subsystem_offset + 2:] == after[subsystem_offset + 2:]
+    # The subsystem WORD itself reads as GUI (2).
+    assert struct.unpack_from("<H", after, subsystem_offset)[0] == 2
+
+
+def test_set_subsystem_rejects_invalid_string(tmp_path: Path):
+    exe = _copy_python_exe(tmp_path)
+    with pytest.raises(ValueError, match="neither"):
+        set_pe_subsystem(exe, "neither")
+
+
+def test_set_subsystem_rejects_empty_string(tmp_path: Path):
+    exe = _copy_python_exe(tmp_path)
+    with pytest.raises(ValueError):
+        set_pe_subsystem(exe, "")


### PR DESCRIPTION
## Summary

Adds `[build.entries.<stem>].subsystem = "gui" | "console"` for per-entry PE subsystem selection. Today, bundled exes inherit GUI vs Console from whichever python runtime variant gets copied (`pythonw.exe` / `python.exe`), driven by the top-level `--gui` / `console = ...` flag plus per-file `file_has_gui_imports()` autodetect. That autodetect flags helpers like update checkers as GUI when they import toast / tray libraries (`windows_toasts`, `pystray`, etc.), leaving them without a usable stdin/stdout.

The new key is an explicit override. When absent, behavior is unchanged.

```toml
[project]
name = "MyApp"
entry = ["MyApp.py", "update_checker.py", "myapp_setup_helper.py"]

[build.entries.update_checker]
subsystem = "console"

[build.entries.myapp_setup_helper]
subsystem = "console"
```

## Details

- `set_pe_subsystem` now accepts `"gui"` / `"console"` strings in addition to the existing `bool`; invalid strings raise `ValueError`.
- New `config.get_subsystem_config(raw, entry_name)` — returns `"gui"`, `"console"`, or `None`; raises `ValueError` naming the entry on invalid values.
- CLI resolves a `{stem: "gui"|"console"}` dict and threads it through `builder.build()` → `package_bundled` / `package_portable`.
- Applied at three seams:
  - `_build_app_directory` primary entry — explicit value controls both the `pythonw.exe`/`python.exe` copy choice and the post-hoc PE stamp.
  - `package_bundled` multi-entry extras loop — explicit value beats `file_has_gui_imports` autodetect.
  - `package_portable` bootloader-stub pass — stub gets stamped the same way.
- When an override is applied, `BuildUI.detail` logs: `Subsystem 'console' applied to entry 'update_checker' (explicit override)`.

No auto-inference added — the existing `file_has_gui_imports` heuristic is exactly what mis-classifies toast/tray helpers, so doubling down on it wouldn't fix the problem. Explicit-only.

## Test plan

- [x] Unit tests for the PE writer (`tests/test_windows_subsystem.py`): gui/console set-and-read via pefile, bool back-compat, flip-flop round-trip with byte-diff check (only the 2-byte subsystem WORD ever changes), invalid and empty strings raise `ValueError`.
- [x] Unit tests for `get_subsystem_config` (`tests/test_config.py`): absent returns `None`, other-entry-only returns `None`, explicit gui/console returned, invalid and empty values raise with entry in message, full toml round-trip.
- [x] Integration tests + fixture (`tests/fixtures/subsystem_sample/`, `tests/test_subsystem_integration.py`): three entries (default / explicit gui / explicit console) built via `package_bundled` with a synthetic host-derived runtime; parses each exe with pefile and asserts `OPTIONAL_HEADER.Subsystem`. Second test verifies explicit `"console"` override beats top-level `gui=True`.
- [x] Full suite: 271 passed, 9 failed — exactly the pre-existing issue #4 set in `test_packager.py` (`WinError 216` subprocess failures + `test_strip_installed_packages`). No new regressions.