### PR TITLE
Expand bundle default excludes; pin sitecustomize dispatch

### DIFF
--- a/src/coil/obfuscator.py
+++ b/src/coil/obfuscator.py
@@ -81,6 +81,7 @@ def compile_directory(
     optimize: int = 0,
     progress_callback: Optional[Callable[[int, int, Path], None]] = None,
     runtime_python: Optional[Path] = None,
+    skip: Optional[Callable[[Path], bool]] = None,
 ) -> list[Path]:
     """Compile all .py files in a directory to .pyc files.
 
@@ -91,12 +92,17 @@ def compile_directory(
         progress_callback: Optional callback(current, total, file_path).
         runtime_python: Path to the target Python exe for cross-version
             compilation.
+        skip: Optional predicate; .py files for which it returns True are
+            not compiled. Used to honor .coilignore / default-exclude
+            patterns so helper scripts don't land in _internal/app/.
 
     Returns:
         List of compiled .pyc file paths.
     """
     compiled: list[Path] = []
     py_files = sorted(source_dir.rglob("*.py"))
+    if skip is not None:
+        py_files = [p for p in py_files if not skip(p)]
     total = len(py_files)
 
     for i, py_file in enumerate(py_files):
@@ -116,6 +122,7 @@ def obfuscate_default(
     ui: Optional[BuildUI] = None,
     optimize: int = 1,
     runtime_python: Optional[Path] = None,
+    skip: Optional[Callable[[Path], bool]] = None,
 ) -> Path:
     """Default obfuscation: compile to .pyc and embed recoverable source.
 
@@ -128,6 +135,8 @@ def obfuscate_default(
         ui: Optional BuildUI for progress display.
         optimize: Bytecode optimization level (0, 1, or 2). Default 1
                   strips assert statements for smaller bytecode.
+        skip: Optional predicate excluding files from compilation AND the
+            recovery archive.
 
     Returns:
         Path to the output directory containing compiled files.
@@ -135,9 +144,10 @@ def obfuscate_default(
     app_dir = output_dir / "app"
     app_dir.mkdir(parents=True, exist_ok=True)
 
-    # Compile all .py to .pyc
     if ui is not None:
         py_files = sorted(source_dir.rglob("*.py"))
+        if skip is not None:
+            py_files = [p for p in py_files if not skip(p)]
         total = len(py_files)
         with ui.file_progress("Compiling source", total=total) as progress:
             task = progress.add_task("", total=total)
@@ -145,18 +155,20 @@ def obfuscate_default(
             def _cb(current: int, total: int, path: Path) -> None:
                 progress.advance(task)
 
-            compile_directory(source_dir, app_dir, optimize=optimize, progress_callback=_cb, runtime_python=runtime_python)
+            compile_directory(source_dir, app_dir, optimize=optimize, progress_callback=_cb, runtime_python=runtime_python, skip=skip)
     else:
-        compile_directory(source_dir, app_dir, optimize=optimize, runtime_python=runtime_python)
+        compile_directory(source_dir, app_dir, optimize=optimize, runtime_python=runtime_python, skip=skip)
 
-    # Archive original source for recovery
+    # Archive original source for recovery — honors the same filter so the
+    # archive mirrors what's compiled.
     source_archive = app_dir / COIL_SOURCE_ARCHIVE
     with zipfile.ZipFile(source_archive, "w", zipfile.ZIP_DEFLATED) as zf:
         for py_file in source_dir.rglob("*.py"):
+            if skip is not None and skip(py_file):
+                continue
             arcname = str(py_file.relative_to(source_dir))
             zf.write(py_file, arcname)
 
-    # Write metadata
     metadata = {
         "coil_version": _get_version(),
         "secure": False,
@@ -175,6 +187,7 @@ def obfuscate_secure(
     ui: Optional[BuildUI] = None,
     optimize: int = 2,
     runtime_python: Optional[Path] = None,
+    skip: Optional[Callable[[Path], bool]] = None,
 ) -> Path:
     """Secure obfuscation: bytecode-only, no recoverable source.
 
@@ -187,6 +200,7 @@ def obfuscate_secure(
         ui: Optional BuildUI for progress display.
         optimize: Bytecode optimization level. Default 2 strips
                   docstrings and assert statements.
+        skip: Optional predicate excluding files from compilation.
 
     Returns:
         Path to the output directory containing compiled files.
@@ -194,9 +208,10 @@ def obfuscate_secure(
     app_dir = output_dir / "app"
     app_dir.mkdir(parents=True, exist_ok=True)
 
-    # Compile with specified optimization level
     if ui is not None:
         py_files = sorted(source_dir.rglob("*.py"))
+        if skip is not None:
+            py_files = [p for p in py_files if not skip(p)]
         total = len(py_files)
         with ui.file_progress("Compiling source", total=total) as progress:
             task = progress.add_task("", total=total)
@@ -204,11 +219,10 @@ def obfuscate_secure(
             def _cb(current: int, total: int, path: Path) -> None:
                 progress.advance(task)
 
-            compile_directory(source_dir, app_dir, optimize=optimize, progress_callback=_cb, runtime_python=runtime_python)
+            compile_directory(source_dir, app_dir, optimize=optimize, progress_callback=_cb, runtime_python=runtime_python, skip=skip)
     else:
-        compile_directory(source_dir, app_dir, optimize=optimize, runtime_python=runtime_python)
+        compile_directory(source_dir, app_dir, optimize=optimize, runtime_python=runtime_python, skip=skip)
 
-    # Write metadata marking this as secure (no source archive)
     metadata = {
         "coil_version": _get_version(),
         "secure": True,

--- a/src/coil/packager.py
+++ b/src/coil/packager.py
@@ -431,6 +431,12 @@ def _build_app_directory(
         else:
             shutil.copy2(item, internal_dir / item.name)
 
+    # Build one exclude matcher (DEFAULT_EXCLUDE_PATTERNS + .coilignore) and
+    # apply it both to the project-asset copier and the obfuscator — a file
+    # that doesn't belong at bundle root also doesn't belong as a .pyc under
+    # _internal/app/.
+    exclude_matcher = _build_exclude_matcher(project_dir)
+
     # Strip unused modules from stdlib zip
     from coil.scanner import scan_project
     project_imports = scan_project(project_dir)
@@ -459,9 +465,9 @@ def _build_app_directory(
     # Default optimize: 1 for default mode, 2 for secure mode
     opt_level = optimize if optimize is not None else (2 if secure else 1)
     if secure:
-        obfuscate_secure(project_dir, internal_dir, ui=ui, optimize=opt_level, runtime_python=runtime_python)
+        obfuscate_secure(project_dir, internal_dir, ui=ui, optimize=opt_level, runtime_python=runtime_python, skip=exclude_matcher)
     else:
-        obfuscate_default(project_dir, internal_dir, ui=ui, optimize=opt_level, runtime_python=runtime_python)
+        obfuscate_default(project_dir, internal_dir, ui=ui, optimize=opt_level, runtime_python=runtime_python, skip=exclude_matcher)
     if ui is not None:
         ui.detail(f"Compiled source ({'secure' if secure else 'default'} mode, optimize={opt_level})")
     elif verbose:
@@ -532,7 +538,7 @@ def _build_app_directory(
             pass
 
     # Copy project assets (icons, configs, etc.) to root
-    _copy_project_assets(project_dir, stage_dir, verbose, ui=ui)
+    _copy_project_assets(project_dir, stage_dir, verbose, ui=ui, exclude_matcher=exclude_matcher)
 
 
 def _zip_directory(
@@ -811,37 +817,152 @@ def _get_python_ver_tag(runtime_dir: Path) -> str:
     return best_tag
 
 
+# Baseline project-root items that should never end up in a Coil bundle:
+# build/packaging metadata, VCS state, caches, virtualenvs, installer
+# scripts, and common docs. Each downstream project's build.bat used to
+# delete these by hand after `coil build`; they're excluded at the source
+# now so that tail can shrink to zero.
+DEFAULT_EXCLUDE_PATTERNS: list[str] = [
+    # Python caches and bytecode artifacts
+    "__pycache__/",
+    ".pytest_cache/",
+    ".mypy_cache/",
+    ".ruff_cache/",
+    ".tox/",
+    "*.egg-info/",
+    # Build output directories
+    "build/",
+    "dist/",
+    "Output/",
+    # VCS / editor metadata
+    ".git/",
+    ".github/",
+    ".vscode/",
+    ".idea/",
+    ".gitignore",
+    ".gitattributes",
+    ".editorconfig",
+    ".coilignore",
+    # Virtualenvs / dependency trees
+    ".venv/",
+    "venv/",
+    "node_modules/",
+    ".env",
+    # Build system / packaging config
+    "coil.toml",
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    "MANIFEST.in",
+    "build.bat",
+    "Makefile",
+    "tox.ini",
+    "pytest.ini",
+    ".flake8",
+    ".pylintrc",
+    "Dockerfile",
+    ".dockerignore",
+    # Requirements / lock files
+    "requirements*.txt",
+    "req.txt",
+    "req-*.txt",
+    # Installer artifacts
+    "*.iss",
+    # Common top-level docs
+    "README*",
+    "LICENSE*",
+    "CHANGELOG*",
+    "CONTRIBUTING*",
+    "CODE_OF_CONDUCT*",
+    "SECURITY*",
+    # Stray logs / prompt scratch
+    "*.log",
+    "prompt.md",
+]
+
+
 def _load_coilignore(project_dir: Path) -> list[str]:
     """Load .coilignore patterns from the project directory.
 
     Works like .gitignore — one glob pattern per line, # for comments,
-    blank lines ignored.
+    blank lines ignored, `!pattern` to re-include a file the defaults (or
+    an earlier pattern) would exclude. `\\!` / `\\#` escape literal leading
+    chars.
     """
     ignore_file = project_dir / ".coilignore"
     if not ignore_file.is_file():
         return []
-    patterns = []
+    patterns: list[str] = []
     for line in ignore_file.read_text(encoding="utf-8").splitlines():
         line = line.strip()
-        if line and not line.startswith("#"):
-            patterns.append(line)
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("\\!") or line.startswith("\\#"):
+            line = line[1:]
+        patterns.append(line)
     return patterns
 
 
-def _is_coilignored(path: Path, project_dir: Path, patterns: list[str]) -> bool:
-    """Check if a path matches any .coilignore pattern."""
+def _single_pattern_match(pattern: str, name: str, rel: str, is_dir: bool) -> bool:
+    """Match one fnmatch pattern against a path's name and project-relative form.
+
+    Directory patterns end with "/" and only match directories.
+    """
     import fnmatch
-    rel = str(path.relative_to(project_dir)).replace("\\", "/")
-    name = path.name
-    for pattern in patterns:
-        if fnmatch.fnmatch(name, pattern):
-            return True
-        if fnmatch.fnmatch(rel, pattern):
-            return True
-        # Support directory patterns like "somedir/"
-        if pattern.endswith("/") and path.is_dir() and fnmatch.fnmatch(name, pattern.rstrip("/")):
-            return True
-    return False
+    if pattern.endswith("/"):
+        if not is_dir:
+            return False
+        stripped = pattern.rstrip("/")
+        return fnmatch.fnmatch(name, stripped) or fnmatch.fnmatch(rel, stripped)
+    return fnmatch.fnmatch(name, pattern) or fnmatch.fnmatch(rel, pattern)
+
+
+def _eval_patterns(
+    name: str,
+    rel: str,
+    is_dir: bool,
+    patterns: list[str],
+) -> bool:
+    """Apply last-match-wins exclusion evaluation against one path identity."""
+    excluded = False
+    for raw in patterns:
+        negate = raw.startswith("!")
+        pattern = raw[1:] if negate else raw
+        if _single_pattern_match(pattern, name, rel, is_dir):
+            excluded = not negate
+    return excluded
+
+
+def _build_exclude_matcher(project_dir: Path) -> Callable[[Path], bool]:
+    """Build a predicate that returns True when a path should be excluded.
+
+    Evaluates DEFAULT_EXCLUDE_PATTERNS first, then the user's .coilignore,
+    last-match-wins per gitignore semantics. Two extensions:
+      * `!pattern` re-includes a leaf an earlier pattern would have excluded.
+      * An excluded ancestor directory cascades to its whole subtree — a
+        `!` pattern on a child cannot override a parent exclusion
+        (matches git's documented behavior).
+    """
+    patterns = list(DEFAULT_EXCLUDE_PATTERNS) + _load_coilignore(project_dir)
+
+    def matches(path: Path) -> bool:
+        try:
+            rel_parts = path.relative_to(project_dir).parts
+        except ValueError:
+            return False
+        for i in range(1, len(rel_parts)):
+            ancestor_name = rel_parts[i - 1]
+            ancestor_rel = "/".join(rel_parts[:i])
+            if _eval_patterns(ancestor_name, ancestor_rel, True, patterns):
+                return True
+        return _eval_patterns(
+            path.name,
+            "/".join(rel_parts),
+            path.is_dir(),
+            patterns,
+        )
+
+    return matches
 
 
 def _copy_project_assets(
@@ -849,35 +970,23 @@ def _copy_project_assets(
     dest_dir: Path,
     verbose: bool = False,
     ui: Optional[BuildUI] = None,
+    exclude_matcher: Optional[Callable[[Path], bool]] = None,
 ) -> None:
     """Copy non-code assets from the project directory into the output.
 
     Copies files like .ico, .png, .json, .cfg, etc. that the app may
-    reference at runtime via relative paths. Respects .coilignore patterns.
+    reference at runtime via relative paths. Code (.py/.pyc/etc.) lives in
+    _internal/app/; everything in DEFAULT_EXCLUDE_PATTERNS plus the user's
+    .coilignore is dropped.
     """
-    skip_extensions = {".py", ".pyc", ".pyo", ".pyd", ".pyi"}
-    skip_files = {
-        "requirements.txt", "pyproject.toml", "setup.py", "setup.cfg",
-        "Makefile", "Dockerfile", ".dockerignore",
-        ".gitignore", ".gitattributes", ".editorconfig",
-        "tox.ini", "pytest.ini", ".flake8", ".pylintrc",
-        "MANIFEST.in", "LICENSE", "CHANGELOG.md", "CONTRIBUTING.md",
-        ".coilignore",
-    }
-    skip_names = {
-        "__pycache__", ".git", ".venv", "venv", ".env", "node_modules",
-        "dist", "build", ".mypy_cache", ".pytest_cache", ".tox",
-        ".github", ".vscode", ".idea", "egg-info",
-    }
-
-    ignore_patterns = _load_coilignore(project_dir)
+    code_extensions = {".py", ".pyc", ".pyo", ".pyd", ".pyi"}
+    if exclude_matcher is None:
+        exclude_matcher = _build_exclude_matcher(project_dir)
 
     for item in project_dir.iterdir():
-        if item.name in skip_names or item.name.lower() in skip_files:
+        if exclude_matcher(item):
             continue
-        if ignore_patterns and _is_coilignored(item, project_dir, ignore_patterns):
-            continue
-        if item.is_file() and item.suffix.lower() not in skip_extensions:
+        if item.is_file() and item.suffix.lower() not in code_extensions:
             dest = dest_dir / item.name
             if not dest.exists():
                 shutil.copy2(item, dest)
@@ -885,11 +994,11 @@ def _copy_project_assets(
                     ui.detail(f"Copied asset: {item.name}")
                 elif verbose:
                     print(f"  Copied asset: {item.name}")
-        elif item.is_dir() and item.name not in skip_names:
+        elif item.is_dir():
             dest = dest_dir / item.name
             if not dest.exists():
                 has_assets = any(
-                    f.suffix.lower() not in skip_extensions
+                    f.suffix.lower() not in code_extensions
                     for f in item.rglob("*") if f.is_file()
                 )
                 if has_assets:

--- a/tests/test_default_excludes.py
+++ b/tests/test_default_excludes.py
@@ -1,0 +1,367 @@
+"""Tests for default exclude patterns, .coilignore parsing, and the
+obfuscator's respect for the same matcher.
+
+Covers:
+  * _single_pattern_match behavior (file globs, dir patterns)
+  * _load_coilignore (comments, blank lines, negation preserved, escapes)
+  * _build_exclude_matcher (defaults, user union, negation, ancestor cascade)
+  * Integration: package_bundled doesn't leak common noise into the bundle
+  * Integration: obfuscator skips ignored helper scripts
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from coil.packager import (
+    DEFAULT_EXCLUDE_PATTERNS,
+    _build_exclude_matcher,
+    _load_coilignore,
+    _single_pattern_match,
+    package_bundled,
+)
+
+
+# ---------------------------------------------------------------------------
+# _single_pattern_match
+# ---------------------------------------------------------------------------
+
+
+def test_single_pattern_match_literal_filename():
+    assert _single_pattern_match("build.bat", "build.bat", "build.bat", False)
+    assert not _single_pattern_match("build.bat", "Other.bat", "Other.bat", False)
+
+
+def test_single_pattern_match_glob():
+    assert _single_pattern_match("*.log", "app.log", "app.log", False)
+    assert _single_pattern_match("req-*.txt", "req-dev.txt", "req-dev.txt", False)
+    assert not _single_pattern_match("*.log", "app.txt", "app.txt", False)
+
+
+def test_single_pattern_match_dir_pattern_matches_only_dirs():
+    # Directory pattern: must be a dir
+    assert _single_pattern_match("Output/", "Output", "Output", True)
+    assert not _single_pattern_match("Output/", "Output", "Output", False)
+
+
+def test_single_pattern_match_egg_info_glob():
+    assert _single_pattern_match("*.egg-info/", "pkg.egg-info", "pkg.egg-info", True)
+    assert not _single_pattern_match("*.egg-info/", "egg-info", "egg-info", False)
+
+
+def test_single_pattern_match_rel_path():
+    # When name doesn't match but path-relative form does
+    assert _single_pattern_match(
+        "docs/*.md", "intro.md", "docs/intro.md", False
+    )
+
+
+# ---------------------------------------------------------------------------
+# _load_coilignore
+# ---------------------------------------------------------------------------
+
+
+def test_load_coilignore_missing_file_returns_empty(tmp_path: Path):
+    assert _load_coilignore(tmp_path) == []
+
+
+def test_load_coilignore_basic(tmp_path: Path):
+    (tmp_path / ".coilignore").write_text(
+        "foo.txt\n*.bak\n\n# comment\n  spaces-trimmed  \n",
+        encoding="utf-8",
+    )
+    assert _load_coilignore(tmp_path) == ["foo.txt", "*.bak", "spaces-trimmed"]
+
+
+def test_load_coilignore_preserves_negation_prefix(tmp_path: Path):
+    (tmp_path / ".coilignore").write_text("!keep.md\n", encoding="utf-8")
+    assert _load_coilignore(tmp_path) == ["!keep.md"]
+
+
+def test_load_coilignore_escape_bang(tmp_path: Path):
+    (tmp_path / ".coilignore").write_text("\\!literal_bang.txt\n", encoding="utf-8")
+    # Leading \! strips to !literal_bang.txt (the literal name)
+    assert _load_coilignore(tmp_path) == ["!literal_bang.txt"]
+
+
+def test_load_coilignore_escape_hash(tmp_path: Path):
+    (tmp_path / ".coilignore").write_text("\\#hashed.py\n", encoding="utf-8")
+    assert _load_coilignore(tmp_path) == ["#hashed.py"]
+
+
+# ---------------------------------------------------------------------------
+# _build_exclude_matcher — default coverage + user extensions
+# ---------------------------------------------------------------------------
+
+
+def _touch(root: Path, *rels: str) -> list[Path]:
+    paths = []
+    for rel in rels:
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        if rel.endswith("/"):
+            (root / rel.rstrip("/")).mkdir(parents=True, exist_ok=True)
+            paths.append(root / rel.rstrip("/"))
+        else:
+            p.write_text("", encoding="utf-8")
+            paths.append(p)
+    return paths
+
+
+def test_defaults_exclude_common_leakage(tmp_path: Path):
+    """The items downstream build.bat scripts delete by hand should all be
+    caught by DEFAULT_EXCLUDE_PATTERNS — no .coilignore needed."""
+    _touch(
+        tmp_path,
+        "build.bat",
+        "coil.toml",
+        "MyAppSetup.iss",
+        "req.txt",
+        "req-dev.txt",
+        "requirements.txt",
+        "README.md",
+        "LICENSE",
+        "LICENSE.txt",
+        "CHANGELOG.md",
+        "app.log",
+        "prompt.md",
+        ".gitignore",
+        ".coilignore",
+        "pyproject.toml",
+        "setup.py",
+        "Makefile",
+        "Output/",
+        "__pycache__/",
+        "pkg.egg-info/",
+        "src.egg-info/",
+        ".github/",
+        ".venv/",
+        "build/",
+        "dist/",
+    )
+    matches = _build_exclude_matcher(tmp_path)
+    for rel in [
+        "build.bat", "coil.toml", "MyAppSetup.iss", "req.txt", "req-dev.txt",
+        "requirements.txt", "README.md", "LICENSE", "LICENSE.txt",
+        "CHANGELOG.md", "app.log", "prompt.md", ".gitignore", ".coilignore",
+        "pyproject.toml", "setup.py", "Makefile", "Output", "__pycache__",
+        "pkg.egg-info", "src.egg-info", ".github", ".venv", "build", "dist",
+    ]:
+        assert matches(tmp_path / rel), f"expected default exclude for {rel}"
+
+
+def test_defaults_allow_legitimate_assets(tmp_path: Path):
+    """Regular project assets should NOT be default-excluded."""
+    _touch(
+        tmp_path,
+        "app.ico",
+        "config.json",
+        "data.csv",
+        "assets/logo.png",
+        "main.py",
+        "helpers.py",
+        "mypkg/__init__.py",
+    )
+    matches = _build_exclude_matcher(tmp_path)
+    for rel in [
+        "app.ico", "config.json", "data.csv", "assets",
+        "assets/logo.png", "main.py", "helpers.py", "mypkg",
+        "mypkg/__init__.py",
+    ]:
+        assert not matches(tmp_path / rel), f"unexpected exclude: {rel}"
+
+
+def test_user_negation_reincludes_default_exclude(tmp_path: Path):
+    """A user who really does want README.md in the bundle can !README* in
+    .coilignore to override the default."""
+    _touch(tmp_path, "README.md")
+    (tmp_path / ".coilignore").write_text("!README*\n", encoding="utf-8")
+    matches = _build_exclude_matcher(tmp_path)
+    assert not matches(tmp_path / "README.md")
+
+
+def test_user_coilignore_adds_to_defaults(tmp_path: Path):
+    """User can add project-specific exclusions on top of defaults."""
+    _touch(tmp_path, "main.py", "set_console.py", "fix_sitecustomize.py")
+    (tmp_path / ".coilignore").write_text(
+        "set_console.py\nfix_sitecustomize.py\n", encoding="utf-8"
+    )
+    matches = _build_exclude_matcher(tmp_path)
+    assert matches(tmp_path / "set_console.py")
+    assert matches(tmp_path / "fix_sitecustomize.py")
+    assert not matches(tmp_path / "main.py")
+
+
+def test_ancestor_directory_exclusion_cascades(tmp_path: Path):
+    """Files under an excluded directory are themselves excluded, even if
+    they don't match any pattern directly (gitignore semantics)."""
+    _touch(tmp_path, "build/internal/artifact.bin")
+    matches = _build_exclude_matcher(tmp_path)
+    # build/ is in defaults; the nested file inherits the exclusion
+    assert matches(tmp_path / "build" / "internal" / "artifact.bin")
+
+
+def test_negation_cannot_reinclude_from_excluded_dir(tmp_path: Path):
+    """Git's rule: once a parent dir is excluded, you can't re-include a
+    child with !pattern. We follow that."""
+    _touch(tmp_path, "build/keepme.txt")
+    (tmp_path / ".coilignore").write_text("!build/keepme.txt\n", encoding="utf-8")
+    matches = _build_exclude_matcher(tmp_path)
+    assert matches(tmp_path / "build" / "keepme.txt")
+
+
+def test_dir_pattern_doesnt_match_file_of_same_name(tmp_path: Path):
+    """A pattern like `Output/` should not exclude a file literally named
+    `Output` (no extension)."""
+    _touch(tmp_path, "Output")  # not a dir
+    matches = _build_exclude_matcher(tmp_path)
+    # The file `Output` is not a directory, so `Output/` doesn't match.
+    # But note: nothing else in defaults matches plain "Output" file either.
+    assert not matches(tmp_path / "Output")
+
+
+# ---------------------------------------------------------------------------
+# Integration: package_bundled doesn't leak common noise
+# ---------------------------------------------------------------------------
+
+
+def _find_embed_zip() -> Path:
+    cache = Path.home() / ".coil" / "cache" / "runtimes"
+    if not cache.is_dir():
+        pytest.skip(f"No embeddable runtime cache at {cache}.")
+    host = f"{sys.version_info.major}.{sys.version_info.minor}"
+    preferred = sorted(cache.glob(f"python-{host}.*-embed-amd64.zip"))
+    if preferred:
+        return preferred[-1]
+    fallback = sorted(cache.glob("python-*-embed-amd64.zip"))
+    if fallback:
+        return fallback[-1]
+    pytest.skip(f"No embeddable Python zip in {cache}.")
+
+
+def _make_real_runtime(tmp_path: Path) -> Path:
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    with zipfile.ZipFile(_find_embed_zip(), "r") as zf:
+        zf.extractall(runtime)
+    return runtime
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only bundle build")
+def test_bundled_build_does_not_leak_project_noise(tmp_path: Path):
+    """End-to-end: a project full of typical root-level noise produces a
+    bundle with only the legitimate assets at root and only declared code
+    under _internal/app/."""
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    # Legitimate code
+    (project / "main.py").write_text("def run(): pass\n", encoding="utf-8")
+    (project / "helpers.py").write_text("def util(): pass\n", encoding="utf-8")
+    # Legitimate asset
+    (project / "feather.ico").write_bytes(b"\x00\x00\x01\x00")
+    (project / "config.json").write_text("{}", encoding="utf-8")
+
+    # Noise that should be excluded by defaults
+    for name in [
+        "build.bat",
+        "coil.toml",
+        "MyAppSetup.iss",
+        "req.txt",
+        "requirements.txt",
+        "README.md",
+        "LICENSE",
+        "CHANGELOG.md",
+        "app.log",
+        "prompt.md",
+        ".gitignore",
+        "pyproject.toml",
+        "setup.py",
+        "Makefile",
+    ]:
+        (project / name).write_text("noise\n", encoding="utf-8")
+    for dname in [".github", "__pycache__", "Output", "pkg.egg-info", ".venv", "build", "dist"]:
+        (project / dname).mkdir()
+        (project / dname / "leaked.txt").write_text("leak\n", encoding="utf-8")
+
+    # User .coilignore adds a project-specific helper
+    (project / "set_console.py").write_text("# helper\n", encoding="utf-8")
+    (project / ".coilignore").write_text("set_console.py\n", encoding="utf-8")
+
+    runtime = _make_real_runtime(tmp_path)
+    output = tmp_path / "dist"
+
+    bundle = package_bundled(
+        project_dir=project,
+        output_dir=output,
+        runtime_dir=runtime,
+        entry_points=["main.py"],
+        name="MyApp",
+        target_os="windows",
+    )
+    assert bundle.is_dir()
+
+    root_files = {p.name for p in bundle.iterdir() if p.is_file()}
+    root_dirs = {p.name for p in bundle.iterdir() if p.is_dir()}
+
+    # Legitimate assets copied
+    assert "feather.ico" in root_files
+    assert "config.json" in root_files
+
+    # All default-excluded noise is gone from bundle root
+    for should_miss in [
+        "build.bat", "coil.toml", "MyAppSetup.iss", "req.txt", "requirements.txt",
+        "README.md", "LICENSE", "CHANGELOG.md", "app.log", "prompt.md",
+        ".gitignore", "pyproject.toml", "setup.py", "Makefile", ".coilignore",
+        "set_console.py",
+    ]:
+        assert should_miss not in root_files, f"{should_miss} leaked into bundle root"
+    for should_miss in [
+        ".github", "__pycache__", "Output", "pkg.egg-info", ".venv", "build", "dist",
+    ]:
+        assert should_miss not in root_dirs, f"{should_miss}/ leaked into bundle root"
+
+    # Obfuscator respects the same matcher: set_console.pyc must not be in _internal/app/
+    app_dir = bundle / "_internal" / "app"
+    assert app_dir.is_dir()
+    compiled = {p.stem for p in app_dir.glob("*.pyc")}
+    assert "main" in compiled
+    assert "helpers" in compiled
+    assert "set_console" not in compiled, "user-ignored helper was compiled"
+
+    # Recovery archive also shouldn't contain the excluded helper
+    from coil.obfuscator import COIL_SOURCE_ARCHIVE
+    archive = app_dir / COIL_SOURCE_ARCHIVE
+    if archive.is_file():
+        with zipfile.ZipFile(archive, "r") as zf:
+            archived = set(zf.namelist())
+        assert "set_console.py" not in archived
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only bundle build")
+def test_user_negation_reincludes_readme_in_bundle(tmp_path: Path):
+    """README.md is default-excluded, but `!README.md` in .coilignore re-adds it."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "main.py").write_text("\n", encoding="utf-8")
+    (project / "README.md").write_text("docs\n", encoding="utf-8")
+    (project / ".coilignore").write_text("!README.md\n", encoding="utf-8")
+
+    runtime = _make_real_runtime(tmp_path)
+    output = tmp_path / "dist"
+
+    bundle = package_bundled(
+        project_dir=project,
+        output_dir=output,
+        runtime_dir=runtime,
+        entry_points=["main.py"],
+        name="App",
+        target_os="windows",
+    )
+
+    assert (bundle / "README.md").is_file(), "user-negated README.md was still excluded"

--- a/tests/test_sitecustomize_dispatch.py
+++ b/tests/test_sitecustomize_dispatch.py
@@ -1,0 +1,180 @@
+"""End-to-end tests for sitecustomize exe-to-boot dispatch.
+
+Builds real bundles with a host Python runtime copy, rewrites each produced
+_boot_*.py with a tagged stub, subprocess-runs the exes, and asserts the
+correct boot ran. Covers the four canonical layouts:
+
+  - single entry, no rename        (main.py -> main.exe)
+  - single entry, renamed via name (main.py -> Renamed.exe)
+  - multi entry                    (main.py + worker.py)
+  - multi entry with spaces        (main.py + "Helper With Space.py")
+
+If any of these misroute, the generated sitecustomize has a live dispatch
+bug (not just a latent one in the Step 2/3 fallbacks).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="sitecustomize dispatch uses the python.exe launcher (Windows-only)",
+)
+
+
+def _find_embed_zip() -> Path:
+    """Locate a cached Windows embeddable Python zip.
+
+    Prefers a version matching the host interpreter (so runtime_python pyc
+    magic is compatible with pytest's compile step). Falls back to any
+    available embeddable zip.
+    """
+    cache = Path.home() / ".coil" / "cache" / "runtimes"
+    if not cache.is_dir():
+        pytest.skip(
+            f"No embeddable Python cache at {cache}. "
+            "Run any `coil build` to populate it."
+        )
+    host = f"{sys.version_info.major}.{sys.version_info.minor}"
+    preferred = sorted(cache.glob(f"python-{host}.*-embed-amd64.zip"))
+    if preferred:
+        return preferred[-1]
+    fallback = sorted(cache.glob("python-*-embed-amd64.zip"))
+    if fallback:
+        return fallback[-1]
+    pytest.skip(f"No embeddable Python zip in {cache}.")
+
+
+def _make_real_runtime(tmp_path: Path) -> Path:
+    """Extract a cached embeddable Python distribution as the build runtime.
+
+    A full embeddable dist is required (not just python.exe + DLLs): the
+    generated sitecustomize runs under a renamed python.exe, and CPython
+    aborts during init if the bundled stdlib zip is missing `encodings`.
+    """
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+
+    zip_path = _find_embed_zip()
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        zf.extractall(runtime)
+    return runtime
+
+
+def _fake_obfuscate(project_dir, internal_dir, ui=None, optimize=0, runtime_python=None, skip=None):
+    """Produce empty .pyc files per .py source. Real compilation isn't needed
+    because the tagged boot stubs exit before touching the pyc."""
+    app_dir = internal_dir / "app"
+    app_dir.mkdir(parents=True, exist_ok=True)
+    for src in project_dir.glob("*.py"):
+        if skip is not None and skip(src):
+            continue
+        (app_dir / (src.stem + ".pyc")).write_bytes(b"")
+
+
+def _tag_boot_scripts(internal_dir: Path) -> list[str]:
+    """Overwrite each _boot_*.py with a stub that prints a tag identifying
+    itself, then exits 0. Returns the stems found."""
+    stems: list[str] = []
+    for boot in internal_dir.glob("_boot_*.py"):
+        stem = boot.name[len("_boot_"):-len(".py")]
+        stems.append(stem)
+        boot.write_text(
+            "import sys\n"
+            f"print('BOOT_TAG={stem}', flush=True)\n"
+            "sys.exit(0)\n",
+            encoding="utf-8",
+        )
+    return stems
+
+
+def _build_and_run(
+    tmp_path: Path,
+    monkeypatch,
+    entries: list[str],
+    name: str,
+) -> dict[str, str]:
+    """Build a bundle, rewrite boot stubs, launch each exe, return {exe_stem: boot_tag}."""
+    from coil.packager import package_bundled
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    for entry in entries:
+        (project / entry).write_text(f"# {entry}\n", encoding="utf-8")
+
+    monkeypatch.setattr("coil.packager.obfuscate_default", _fake_obfuscate)
+    monkeypatch.setattr("coil.packager.obfuscate_secure", _fake_obfuscate)
+
+    runtime = _make_real_runtime(tmp_path)
+    output = tmp_path / "dist"
+
+    bundle = package_bundled(
+        project_dir=project,
+        output_dir=output,
+        runtime_dir=runtime,
+        entry_points=entries,
+        name=name,
+        target_os="windows",
+    )
+    assert bundle.is_dir()
+
+    _tag_boot_scripts(bundle / "_internal")
+
+    observed: dict[str, str] = {}
+    for exe in sorted(bundle.glob("*.exe")):
+        result = subprocess.run(
+            [str(exe)],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            timeout=15,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"{exe.name} exited {result.returncode}: "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        tag = None
+        for line in result.stdout.splitlines():
+            if line.startswith("BOOT_TAG="):
+                tag = line[len("BOOT_TAG="):].strip()
+                break
+        assert tag is not None, (
+            f"{exe.name} produced no BOOT_TAG: "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        observed[exe.stem] = tag
+    return observed
+
+
+def test_single_entry_no_rename(tmp_path: Path, monkeypatch):
+    observed = _build_and_run(tmp_path, monkeypatch, entries=["main.py"], name="main")
+    assert observed == {"main": "main"}
+
+
+def test_single_entry_with_rename(tmp_path: Path, monkeypatch):
+    observed = _build_and_run(tmp_path, monkeypatch, entries=["main.py"], name="Renamed")
+    assert observed == {"Renamed": "Renamed"}
+
+
+def test_multi_entry(tmp_path: Path, monkeypatch):
+    observed = _build_and_run(
+        tmp_path, monkeypatch, entries=["main.py", "worker.py"], name="MultiApp"
+    )
+    assert observed == {"main": "main", "worker": "worker"}
+
+
+def test_multi_entry_with_spaces(tmp_path: Path, monkeypatch):
+    observed = _build_and_run(
+        tmp_path,
+        monkeypatch,
+        entries=["main.py", "Helper With Space.py"],
+        name="SpacedApp",
+    )
+    assert observed == {"main": "main", "Helper With Space": "Helper With Space"}

--- a/tests/test_subsystem_integration.py
+++ b/tests/test_subsystem_integration.py
@@ -83,10 +83,12 @@ def test_bundled_build_stamps_subsystem_per_entry(tmp_path: Path, monkeypatch):
     assert subsystems == {"gui_entry": "gui", "console_entry": "console"}
 
     # Skip real compilation: we don't need real .pyc files.
-    def _fake_obfuscate(project_dir, internal_dir, ui=None, optimize=0, runtime_python=None):
+    def _fake_obfuscate(project_dir, internal_dir, ui=None, optimize=0, runtime_python=None, skip=None):
         app_dir = internal_dir / "app"
         app_dir.mkdir(parents=True, exist_ok=True)
         for src in project_dir.glob("*.py"):
+            if skip is not None and skip(src):
+                continue
             (app_dir / (src.stem + ".pyc")).write_bytes(b"")
 
     monkeypatch.setattr("coil.packager.obfuscate_default", _fake_obfuscate)
@@ -121,10 +123,12 @@ def test_bundled_build_explicit_override_beats_gui_flag(tmp_path: Path, monkeypa
 
     subsystems = {"console_entry": "console"}
 
-    def _fake_obfuscate(project_dir, internal_dir, ui=None, optimize=0, runtime_python=None):
+    def _fake_obfuscate(project_dir, internal_dir, ui=None, optimize=0, runtime_python=None, skip=None):
         app_dir = internal_dir / "app"
         app_dir.mkdir(parents=True, exist_ok=True)
         for src in project_dir.glob("*.py"):
+            if skip is not None and skip(src):
+                continue
             (app_dir / (src.stem + ".pyc")).write_bytes(b"")
 
     monkeypatch.setattr("coil.packager.obfuscate_default", _fake_obfuscate)

--- a/tests/test_versioninfo_integration.py
+++ b/tests/test_versioninfo_integration.py
@@ -96,10 +96,12 @@ def test_bundled_build_stamps_versioninfo_from_fixture(tmp_path: Path, monkeypat
     }
 
     # Skip real compilation: we don't need real .pyc files for this test.
-    def _fake_obfuscate(project_dir, internal_dir, ui=None, optimize=0, runtime_python=None):
+    def _fake_obfuscate(project_dir, internal_dir, ui=None, optimize=0, runtime_python=None, skip=None):
         app_dir = internal_dir / "app"
         app_dir.mkdir(parents=True, exist_ok=True)
         for src in project_dir.glob("*.py"):
+            if skip is not None and skip(src):
+                continue
             (app_dir / (src.stem + ".pyc")).write_bytes(b"")
 
     monkeypatch.setattr("coil.packager.obfuscate_default", _fake_obfuscate)


### PR DESCRIPTION
## Summary

Housekeeping cleanup covering two independent concerns.

### 1) Default bundle excludes + `.coilignore` negation

Replaces the three exact-match sets in `_copy_project_assets`
(`skip_extensions` / `skip_files` / `skip_names`) with a single fnmatch
pattern list (`DEFAULT_EXCLUDE_PATTERNS`) merged with `.coilignore` via
gitignore-style last-match-wins. The default list now catches everything
every downstream `build.bat` used to `del` by hand after `coil build`:
`Output/`, `build.bat`, `coil.toml`, `*.iss`, `req.txt`/`req-*.txt`,
`README*`, `*.log`, `prompt.md`, `*.egg-info/`, and the existing
pyproject/setup/Makefile/VCS/cache set (the last was already covered
and is preserved).

`.coilignore` learned:

- `!pattern` negation — re-include a leaf the defaults (or an earlier
  pattern) would have excluded.
- `\!` / `\#` escapes for literal leading chars.
- Ancestor-cascade: once a directory is excluded, its subtree is
  excluded and a child `!pattern` cannot override (git's documented
  rule).

The **obfuscator** now receives the same matcher, so helper scripts a
user lists in `.coilignore` no longer end up as `.pyc` under
`_internal/app/` or inside the recovery source archive.

After this PR every downstream `build.bat`'s `if exist … del` tail can
collapse to zero lines for projects that stick to the defaults, or to
a single-line `.coilignore` for project-specific oddities.

### 2) Sitecustomize dispatch regression test

New `tests/test_sitecustomize_dispatch.py` builds real bundles with a
cached embeddable Python runtime, rewrites each generated `_boot_*.py`
with a tagged stub, subprocess-launches each produced exe, and asserts
the right boot ran. Covers the four canonical layouts:

- single entry, no rename         (`main.py → main.exe`)
- single entry, renamed via name  (`main.py → Renamed.exe`)
- multi entry                     (`main.py + worker.py`)
- multi entry with spaces         (`main.py + "Helper With Space.py"`)

**Finding:** all four pass against the current dispatch. Step 1 (exact
`_boot_<exe>.py` lookup) matches for every canonical layout Coil
produces. Steps 2 (substring scan against a lowercased exe name) and 3
(hardcoded `entry_name` fallback) in the generated sitecustomize are
latent — they would misroute if an exe were renamed *post-build* (case
inconsistency in Step 2, ambiguity when boot stems are prefixes of each
other, non-primary exe falling through to Step 3), but that's not a
path Coil itself produces. Per the task's guardrail, the dispatch code
is unchanged here; the regression test now captures the current
behavior so any future change has to keep the four shapes routing
correctly.

### Other

Mocks in two existing integration tests (subsystem + versioninfo) got
the new `skip=None` kwarg so they stay signature-compatible with the
real obfuscator.

## Test plan

- [x] New `tests/test_sitecustomize_dispatch.py` — four shapes, all pass
- [x] New `tests/test_default_excludes.py` — 19 unit + integration tests
      (pattern matcher, `.coilignore` parser, defaults coverage,
      negation, ancestor cascade, full `package_bundled` run)
- [x] Full suite: 294 passed, 9 failed — exactly the 9 pre-existing
      issue #4 failures. No new regressions.