### PR TITLE
Hoist real_runtime into a shared fixture; fix 9 failing packager tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,55 @@
+"""Shared pytest fixtures for the Coil test suite."""
+
+from __future__ import annotations
+
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+def _find_cached_embed_zip() -> Path | None:
+    """Locate a cached Windows embeddable Python zip.
+
+    Prefers a zip matching the host Python minor version (so the bundled
+    runtime's ABI matches anything the host's interpreter produces —
+    important for tests that execute produced exes or generated .pyc files).
+    Falls back to any cached embed zip if no host-version match exists.
+    """
+    cache = Path.home() / ".coil" / "cache" / "runtimes"
+    if not cache.is_dir():
+        return None
+    host_short = f"{sys.version_info.major}.{sys.version_info.minor}"
+    preferred = sorted(cache.glob(f"python-{host_short}.*-embed-amd64.zip"))
+    if preferred:
+        return preferred[-1]
+    fallback = sorted(cache.glob("python-*-embed-amd64.zip"))
+    return fallback[-1] if fallback else None
+
+
+@pytest.fixture(scope="session")
+def real_runtime(tmp_path_factory) -> Path:
+    """A Windows embeddable Python runtime extracted to a session-tmp dir.
+
+    Skips when not on Windows or when no cached embed zip is available.
+    Run `coil build` once on any project to populate the cache.
+
+    Session-scoped: extracted once and shared across tests. The Coil
+    packager only reads from runtime_dir (copies out, never mutates),
+    so sharing is safe.
+    """
+    if sys.platform != "win32":
+        pytest.skip("real_runtime fixture is Windows-only")
+
+    zip_path = _find_cached_embed_zip()
+    if zip_path is None:
+        pytest.skip(
+            "No cached embeddable Python runtime at ~/.coil/cache/runtimes. "
+            "Run any `coil build` to populate it."
+        )
+
+    runtime = tmp_path_factory.mktemp("runtime")
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        zf.extractall(runtime)
+    return runtime

--- a/tests/test_default_excludes.py
+++ b/tests/test_default_excludes.py
@@ -11,7 +11,6 @@ Covers:
 
 from __future__ import annotations
 
-import shutil
 import sys
 import zipfile
 from pathlib import Path
@@ -230,30 +229,8 @@ def test_dir_pattern_doesnt_match_file_of_same_name(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def _find_embed_zip() -> Path:
-    cache = Path.home() / ".coil" / "cache" / "runtimes"
-    if not cache.is_dir():
-        pytest.skip(f"No embeddable runtime cache at {cache}.")
-    host = f"{sys.version_info.major}.{sys.version_info.minor}"
-    preferred = sorted(cache.glob(f"python-{host}.*-embed-amd64.zip"))
-    if preferred:
-        return preferred[-1]
-    fallback = sorted(cache.glob("python-*-embed-amd64.zip"))
-    if fallback:
-        return fallback[-1]
-    pytest.skip(f"No embeddable Python zip in {cache}.")
-
-
-def _make_real_runtime(tmp_path: Path) -> Path:
-    runtime = tmp_path / "runtime"
-    runtime.mkdir()
-    with zipfile.ZipFile(_find_embed_zip(), "r") as zf:
-        zf.extractall(runtime)
-    return runtime
-
-
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only bundle build")
-def test_bundled_build_does_not_leak_project_noise(tmp_path: Path):
+def test_bundled_build_does_not_leak_project_noise(tmp_path: Path, real_runtime: Path):
     """End-to-end: a project full of typical root-level noise produces a
     bundle with only the legitimate assets at root and only declared code
     under _internal/app/."""
@@ -293,13 +270,12 @@ def test_bundled_build_does_not_leak_project_noise(tmp_path: Path):
     (project / "set_console.py").write_text("# helper\n", encoding="utf-8")
     (project / ".coilignore").write_text("set_console.py\n", encoding="utf-8")
 
-    runtime = _make_real_runtime(tmp_path)
     output = tmp_path / "dist"
 
     bundle = package_bundled(
         project_dir=project,
         output_dir=output,
-        runtime_dir=runtime,
+        runtime_dir=real_runtime,
         entry_points=["main.py"],
         name="MyApp",
         target_os="windows",
@@ -344,7 +320,7 @@ def test_bundled_build_does_not_leak_project_noise(tmp_path: Path):
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only bundle build")
-def test_user_negation_reincludes_readme_in_bundle(tmp_path: Path):
+def test_user_negation_reincludes_readme_in_bundle(tmp_path: Path, real_runtime: Path):
     """README.md is default-excluded, but `!README.md` in .coilignore re-adds it."""
     project = tmp_path / "proj"
     project.mkdir()
@@ -352,13 +328,12 @@ def test_user_negation_reincludes_readme_in_bundle(tmp_path: Path):
     (project / "README.md").write_text("docs\n", encoding="utf-8")
     (project / ".coilignore").write_text("!README.md\n", encoding="utf-8")
 
-    runtime = _make_real_runtime(tmp_path)
     output = tmp_path / "dist"
 
     bundle = package_bundled(
         project_dir=project,
         output_dir=output,
-        runtime_dir=runtime,
+        runtime_dir=real_runtime,
         entry_points=["main.py"],
         name="App",
         target_os="windows",

--- a/tests/test_packager.py
+++ b/tests/test_packager.py
@@ -41,29 +41,14 @@ def _make_project(base: Path) -> Path:
     return project
 
 
-def _make_runtime(base: Path) -> Path:
-    """Create a fake runtime directory."""
-    runtime = base / "runtime"
-    runtime.mkdir()
-    (runtime / "python.exe").write_bytes(b"MZ" + b"\x00" * 200)
-    (runtime / "pythonw.exe").write_bytes(b"MZ" + b"\x00" * 200)
-    (runtime / "python313.dll").write_bytes(b"fake dll")
-    (runtime / "python3.dll").write_bytes(b"fake dll")
-    (runtime / "vcruntime140.dll").write_bytes(b"fake dll")
-    (runtime / "python313._pth").write_text("python313.zip\n.\n")
-    (runtime / "python313.zip").write_bytes(b"fake zip")
-    return runtime
-
-
-def test_package_bundled(tmp_path: Path):
+def test_package_bundled(tmp_path: Path, real_runtime: Path):
     project = _make_project(tmp_path)
-    runtime = _make_runtime(tmp_path)
     output = tmp_path / "dist"
 
     result = package_bundled(
         project_dir=project,
         output_dir=output,
-        runtime_dir=runtime,
+        runtime_dir=real_runtime,
         entry_points=["main.py"],
         name="MyApp",
         target_os="windows",
@@ -75,18 +60,18 @@ def test_package_bundled(tmp_path: Path):
     assert (result / "MyApp.exe").is_file()
     assert (result / "_internal" / "app" / "main.pyc").is_file()
     assert (result / "_internal" / "app" / "helper.pyc").is_file()
-    assert (result / "python313.dll").is_file()
+    ver_tag = _get_python_ver_tag(real_runtime)
+    assert (result / f"python{ver_tag}.dll").is_file()
 
 
-def test_package_bundled_secure(tmp_path: Path):
+def test_package_bundled_secure(tmp_path: Path, real_runtime: Path):
     project = _make_project(tmp_path)
-    runtime = _make_runtime(tmp_path)
     output = tmp_path / "dist"
 
     result = package_bundled(
         project_dir=project,
         output_dir=output,
-        runtime_dir=runtime,
+        runtime_dir=real_runtime,
         entry_points=["main.py"],
         name="MyApp",
         target_os="windows",
@@ -99,9 +84,8 @@ def test_package_bundled_secure(tmp_path: Path):
     assert not (result / "_internal" / "app" / COIL_SOURCE_ARCHIVE).exists()
 
 
-def test_package_bundled_with_deps(tmp_path: Path):
+def test_package_bundled_with_deps(tmp_path: Path, real_runtime: Path):
     project = _make_project(tmp_path)
-    runtime = _make_runtime(tmp_path)
     output = tmp_path / "dist"
 
     deps = tmp_path / "deps"
@@ -111,7 +95,7 @@ def test_package_bundled_with_deps(tmp_path: Path):
     result = package_bundled(
         project_dir=project,
         output_dir=output,
-        runtime_dir=runtime,
+        runtime_dir=real_runtime,
         entry_points=["main.py"],
         name="MyApp",
         target_os="windows",
@@ -121,16 +105,15 @@ def test_package_bundled_with_deps(tmp_path: Path):
     assert (result / "_internal" / "lib").is_dir()
 
 
-def test_package_portable(tmp_path: Path):
+def test_package_portable(tmp_path: Path, real_runtime: Path):
     """Portable produces a single .exe file (bootloader + zip)."""
     project = _make_project(tmp_path)
-    runtime = _make_runtime(tmp_path)
     output = tmp_path / "dist"
 
     results = package_portable(
         project_dir=project,
         output_dir=output,
-        runtime_dir=runtime,
+        runtime_dir=real_runtime,
         entry_points=["main.py"],
         name="MyApp",
         target_os="windows",
@@ -156,15 +139,14 @@ def test_package_portable(tmp_path: Path):
     assert build_hash != 0
 
 
-def test_package_portable_gui(tmp_path: Path):
+def test_package_portable_gui(tmp_path: Path, real_runtime: Path):
     project = _make_project(tmp_path)
-    runtime = _make_runtime(tmp_path)
     output = tmp_path / "dist"
 
     results = package_portable(
         project_dir=project,
         output_dir=output,
-        runtime_dir=runtime,
+        runtime_dir=real_runtime,
         entry_points=["main.py"],
         name="MyApp",
         target_os="windows",
@@ -176,15 +158,14 @@ def test_package_portable_gui(tmp_path: Path):
     assert results[0].is_file()
 
 
-def test_package_portable_multiple_entries(tmp_path: Path):
+def test_package_portable_multiple_entries(tmp_path: Path, real_runtime: Path):
     project = _make_project(tmp_path)
-    runtime = _make_runtime(tmp_path)
     output = tmp_path / "dist"
 
     results = package_portable(
         project_dir=project,
         output_dir=output,
-        runtime_dir=runtime,
+        runtime_dir=real_runtime,
         entry_points=["main.py", "helper.py"],
         name="MyApp",
         target_os="windows",
@@ -288,7 +269,11 @@ def test_strip_installed_packages(tmp_path: Path):
 
     _strip_installed_packages(tmp_path)
 
-    assert not (tmp_path / "pkg-1.0.dist-info").exists()
+    # .dist-info is preserved on purpose: the resolver uses
+    # importlib.metadata.packages_distributions() to map imports to
+    # distributions at build time, and bundled packages may also call
+    # importlib.metadata at runtime for their own version info.
+    assert (tmp_path / "pkg-1.0.dist-info").exists()
     assert not (tmp_path / "tests").exists()
     assert not (tmp_path / "docs").exists()
     assert (tmp_path / "actual_code.py").exists()
@@ -341,16 +326,15 @@ def test_bootloader_stub_unknown_arch():
         get_bootloader_stub("mips64")
 
 
-def test_package_bundled_optimize_level(tmp_path: Path):
+def test_package_bundled_optimize_level(tmp_path: Path, real_runtime: Path):
     """Optimize level is passed through to obfuscator."""
     project = _make_project(tmp_path)
-    runtime = _make_runtime(tmp_path)
     output = tmp_path / "dist"
 
     result = package_bundled(
         project_dir=project,
         output_dir=output,
-        runtime_dir=runtime,
+        runtime_dir=real_runtime,
         entry_points=["main.py"],
         name="MyApp",
         target_os="windows",
@@ -362,17 +346,16 @@ def test_package_bundled_optimize_level(tmp_path: Path):
     assert (result / "_internal" / "app" / "main.pyc").is_file()
 
 
-def test_package_bundled_optimize_default(tmp_path: Path):
+def test_package_bundled_optimize_default(tmp_path: Path, real_runtime: Path):
     """Default optimize: 1 for non-secure, 2 for secure."""
     project = _make_project(tmp_path)
-    runtime = _make_runtime(tmp_path)
     output = tmp_path / "dist"
 
     # Non-secure default (optimize=None → 1)
     result = package_bundled(
         project_dir=project,
         output_dir=output,
-        runtime_dir=runtime,
+        runtime_dir=real_runtime,
         entry_points=["main.py"],
         name="MyApp",
         target_os="windows",
@@ -383,7 +366,7 @@ def test_package_bundled_optimize_default(tmp_path: Path):
     result2 = package_bundled(
         project_dir=project,
         output_dir=output,
-        runtime_dir=runtime,
+        runtime_dir=real_runtime,
         entry_points=["main.py"],
         name="SecApp",
         target_os="windows",

--- a/tests/test_pywin32_integration.py
+++ b/tests/test_pywin32_integration.py
@@ -72,30 +72,29 @@ def _copy_pywin32(src: Path, dst: Path) -> None:
             shutil.copy2(s, d)
 
 
-def _find_matching_runtime_zip() -> Path | None:
-    from coil.runtime import CACHE_DIR
-    host_short = f"{sys.version_info.major}.{sys.version_info.minor}"
-    matches = sorted(CACHE_DIR.glob(f"python-{host_short}.*-embed-amd64.zip"))
-    return matches[-1] if matches else None
+def _is_host_version_match(runtime: Path) -> bool:
+    """True if the runtime's pythonXX.dll matches the host minor version.
+
+    The bundled pywin32 .pyd files are ABI-specific, so this test only makes
+    sense when the runtime's Python matches the host interpreter that owns
+    the pywin32 install we're copying from.
+    """
+    host_short = f"{sys.version_info.major}{sys.version_info.minor}"
+    return (runtime / f"python{host_short}.dll").is_file()
 
 
-def test_pywin32_import_end_to_end(tmp_path: Path):
+def test_pywin32_import_end_to_end(tmp_path: Path, real_runtime: Path):
     if importlib.util.find_spec("win32pipe") is None:
         pytest.skip("pywin32 not importable in host environment")
     site_pkgs = _host_site_packages()
     if site_pkgs is None or not (site_pkgs / "pywin32.pth").is_file():
         pytest.skip("pywin32.pth not found in host site-packages")
-    runtime_zip = _find_matching_runtime_zip()
-    if runtime_zip is None:
+    if not _is_host_version_match(real_runtime):
         pytest.skip(
-            "No cached Coil runtime matching host Python "
-            f"{sys.version_info.major}.{sys.version_info.minor}"
+            f"real_runtime doesn't match host Python "
+            f"{sys.version_info.major}.{sys.version_info.minor}; "
+            "pywin32 .pyd ABI would mismatch"
         )
-
-    # Extract the real embeddable runtime (stdlib, python.exe, DLLs)
-    from coil.runtime import extract_runtime
-    runtime_dir = tmp_path / "runtime"
-    extract_runtime(runtime_zip, runtime_dir)
 
     # Materialize deps dir mimicking a pip install --target
     deps = tmp_path / "deps"
@@ -116,7 +115,7 @@ def test_pywin32_import_end_to_end(tmp_path: Path):
     bundle = package_bundled(
         project_dir=project,
         output_dir=tmp_path / "dist",
-        runtime_dir=runtime_dir,
+        runtime_dir=real_runtime,
         entry_points=["main.py"],
         name="pywin32probe",
         target_os="windows",

--- a/tests/test_sitecustomize_dispatch.py
+++ b/tests/test_sitecustomize_dispatch.py
@@ -15,10 +15,8 @@ bug (not just a latent one in the Step 2/3 fallbacks).
 
 from __future__ import annotations
 
-import shutil
 import subprocess
 import sys
-import zipfile
 from pathlib import Path
 
 import pytest
@@ -27,45 +25,6 @@ pytestmark = pytest.mark.skipif(
     sys.platform != "win32",
     reason="sitecustomize dispatch uses the python.exe launcher (Windows-only)",
 )
-
-
-def _find_embed_zip() -> Path:
-    """Locate a cached Windows embeddable Python zip.
-
-    Prefers a version matching the host interpreter (so runtime_python pyc
-    magic is compatible with pytest's compile step). Falls back to any
-    available embeddable zip.
-    """
-    cache = Path.home() / ".coil" / "cache" / "runtimes"
-    if not cache.is_dir():
-        pytest.skip(
-            f"No embeddable Python cache at {cache}. "
-            "Run any `coil build` to populate it."
-        )
-    host = f"{sys.version_info.major}.{sys.version_info.minor}"
-    preferred = sorted(cache.glob(f"python-{host}.*-embed-amd64.zip"))
-    if preferred:
-        return preferred[-1]
-    fallback = sorted(cache.glob("python-*-embed-amd64.zip"))
-    if fallback:
-        return fallback[-1]
-    pytest.skip(f"No embeddable Python zip in {cache}.")
-
-
-def _make_real_runtime(tmp_path: Path) -> Path:
-    """Extract a cached embeddable Python distribution as the build runtime.
-
-    A full embeddable dist is required (not just python.exe + DLLs): the
-    generated sitecustomize runs under a renamed python.exe, and CPython
-    aborts during init if the bundled stdlib zip is missing `encodings`.
-    """
-    runtime = tmp_path / "runtime"
-    runtime.mkdir()
-
-    zip_path = _find_embed_zip()
-    with zipfile.ZipFile(zip_path, "r") as zf:
-        zf.extractall(runtime)
-    return runtime
 
 
 def _fake_obfuscate(project_dir, internal_dir, ui=None, optimize=0, runtime_python=None, skip=None):
@@ -98,6 +57,7 @@ def _tag_boot_scripts(internal_dir: Path) -> list[str]:
 def _build_and_run(
     tmp_path: Path,
     monkeypatch,
+    real_runtime: Path,
     entries: list[str],
     name: str,
 ) -> dict[str, str]:
@@ -112,13 +72,12 @@ def _build_and_run(
     monkeypatch.setattr("coil.packager.obfuscate_default", _fake_obfuscate)
     monkeypatch.setattr("coil.packager.obfuscate_secure", _fake_obfuscate)
 
-    runtime = _make_real_runtime(tmp_path)
     output = tmp_path / "dist"
 
     bundle = package_bundled(
         project_dir=project,
         output_dir=output,
-        runtime_dir=runtime,
+        runtime_dir=real_runtime,
         entry_points=entries,
         name=name,
         target_os="windows",
@@ -153,27 +112,36 @@ def _build_and_run(
     return observed
 
 
-def test_single_entry_no_rename(tmp_path: Path, monkeypatch):
-    observed = _build_and_run(tmp_path, monkeypatch, entries=["main.py"], name="main")
+def test_single_entry_no_rename(tmp_path: Path, monkeypatch, real_runtime: Path):
+    observed = _build_and_run(
+        tmp_path, monkeypatch, real_runtime, entries=["main.py"], name="main"
+    )
     assert observed == {"main": "main"}
 
 
-def test_single_entry_with_rename(tmp_path: Path, monkeypatch):
-    observed = _build_and_run(tmp_path, monkeypatch, entries=["main.py"], name="Renamed")
+def test_single_entry_with_rename(tmp_path: Path, monkeypatch, real_runtime: Path):
+    observed = _build_and_run(
+        tmp_path, monkeypatch, real_runtime, entries=["main.py"], name="Renamed"
+    )
     assert observed == {"Renamed": "Renamed"}
 
 
-def test_multi_entry(tmp_path: Path, monkeypatch):
+def test_multi_entry(tmp_path: Path, monkeypatch, real_runtime: Path):
     observed = _build_and_run(
-        tmp_path, monkeypatch, entries=["main.py", "worker.py"], name="MultiApp"
+        tmp_path,
+        monkeypatch,
+        real_runtime,
+        entries=["main.py", "worker.py"],
+        name="MultiApp",
     )
     assert observed == {"main": "main", "worker": "worker"}
 
 
-def test_multi_entry_with_spaces(tmp_path: Path, monkeypatch):
+def test_multi_entry_with_spaces(tmp_path: Path, monkeypatch, real_runtime: Path):
     observed = _build_and_run(
         tmp_path,
         monkeypatch,
+        real_runtime,
         entries=["main.py", "Helper With Space.py"],
         name="SpacedApp",
     )

--- a/tests/test_subsystem_integration.py
+++ b/tests/test_subsystem_integration.py
@@ -6,7 +6,6 @@ exes are stampable PEs. Parses produced exes with pefile.
 
 from __future__ import annotations
 
-import shutil
 import sys
 from pathlib import Path
 
@@ -25,32 +24,6 @@ from coil.packager import package_bundled
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "subsystem_sample"
 
 
-def _make_real_runtime(tmp_path: Path) -> Path:
-    """Synthetic embeddable-like runtime using the host interpreter's files."""
-    runtime = tmp_path / "runtime"
-    runtime.mkdir()
-    host_dir = Path(sys.executable).parent
-
-    for exe_name in ("python.exe", "pythonw.exe"):
-        src = host_dir / exe_name
-        if src.is_file():
-            shutil.copy2(src, runtime / exe_name)
-
-    for pattern in ("python*.dll", "vcruntime*.dll"):
-        for dll in host_dir.glob(pattern):
-            shutil.copy2(dll, runtime / dll.name)
-
-    ver_tag = f"{sys.version_info.major}{sys.version_info.minor}"
-    (runtime / f"python{ver_tag}._pth").write_text(f"python{ver_tag}.zip\n.\n")
-
-    import zipfile
-    zip_path = runtime / f"python{ver_tag}.zip"
-    with zipfile.ZipFile(zip_path, "w") as zf:
-        pass
-
-    return runtime
-
-
 def _read_subsystem(exe_path: Path) -> int:
     pe = pefile.PE(str(exe_path), fast_load=True)
     try:
@@ -59,7 +32,9 @@ def _read_subsystem(exe_path: Path) -> int:
         pe.close()
 
 
-def test_bundled_build_stamps_subsystem_per_entry(tmp_path: Path, monkeypatch):
+def test_bundled_build_stamps_subsystem_per_entry(
+    tmp_path: Path, monkeypatch, real_runtime: Path
+):
     """Full pipeline: 3 entries with different subsystem declarations.
 
     - main: no explicit subsystem → falls through (gui=False by default
@@ -94,13 +69,12 @@ def test_bundled_build_stamps_subsystem_per_entry(tmp_path: Path, monkeypatch):
     monkeypatch.setattr("coil.packager.obfuscate_default", _fake_obfuscate)
     monkeypatch.setattr("coil.packager.obfuscate_secure", _fake_obfuscate)
 
-    runtime = _make_real_runtime(tmp_path)
     output = tmp_path / "dist"
 
     bundle = package_bundled(
         project_dir=FIXTURE_DIR,
         output_dir=output,
-        runtime_dir=runtime,
+        runtime_dir=real_runtime,
         entry_points=entries,
         name="SubsystemSample",
         target_os="windows",
@@ -116,7 +90,9 @@ def test_bundled_build_stamps_subsystem_per_entry(tmp_path: Path, monkeypatch):
     assert _read_subsystem(bundle / "console_entry.exe") == 3
 
 
-def test_bundled_build_explicit_override_beats_gui_flag(tmp_path: Path, monkeypatch):
+def test_bundled_build_explicit_override_beats_gui_flag(
+    tmp_path: Path, monkeypatch, real_runtime: Path
+):
     """Top-level gui=True says GUI for everything, but an explicit
     "console" override on an entry must still produce Console."""
     entries = ["main.py", "console_entry.py"]
@@ -134,13 +110,12 @@ def test_bundled_build_explicit_override_beats_gui_flag(tmp_path: Path, monkeypa
     monkeypatch.setattr("coil.packager.obfuscate_default", _fake_obfuscate)
     monkeypatch.setattr("coil.packager.obfuscate_secure", _fake_obfuscate)
 
-    runtime = _make_real_runtime(tmp_path)
     output = tmp_path / "dist"
 
     bundle = package_bundled(
         project_dir=FIXTURE_DIR,
         output_dir=output,
-        runtime_dir=runtime,
+        runtime_dir=real_runtime,
         entry_points=entries,
         name="SubsystemSample",
         target_os="windows",

--- a/tests/test_versioninfo_integration.py
+++ b/tests/test_versioninfo_integration.py
@@ -6,7 +6,6 @@ exes are stampable PEs. Parses the produced exes with pefile.
 
 from __future__ import annotations
 
-import shutil
 import sys
 from pathlib import Path
 
@@ -23,33 +22,6 @@ from coil.packager import package_bundled
 
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "versioninfo_sample"
-
-
-def _make_real_runtime(tmp_path: Path) -> Path:
-    """Build a synthetic embeddable-like runtime with a real python.exe + DLLs."""
-    runtime = tmp_path / "runtime"
-    runtime.mkdir()
-    host_dir = Path(sys.executable).parent
-
-    for exe_name in ("python.exe", "pythonw.exe"):
-        src = host_dir / exe_name
-        if src.is_file():
-            shutil.copy2(src, runtime / exe_name)
-
-    for pattern in ("python*.dll", "vcruntime*.dll"):
-        for dll in host_dir.glob(pattern):
-            shutil.copy2(dll, runtime / dll.name)
-
-    ver_tag = f"{sys.version_info.major}{sys.version_info.minor}"
-    (runtime / f"python{ver_tag}._pth").write_text(f"python{ver_tag}.zip\n.\n")
-
-    # Minimal valid (empty) zip so _strip_stdlib_zip is a no-op.
-    import zipfile
-    zip_path = runtime / f"python{ver_tag}.zip"
-    with zipfile.ZipFile(zip_path, "w") as zf:
-        pass
-
-    return runtime
 
 
 def _read_version_strings(exe_path: Path) -> dict[str, str]:
@@ -73,7 +45,9 @@ def _read_version_strings(exe_path: Path) -> dict[str, str]:
     return result
 
 
-def test_bundled_build_stamps_versioninfo_from_fixture(tmp_path: Path, monkeypatch):
+def test_bundled_build_stamps_versioninfo_from_fixture(
+    tmp_path: Path, monkeypatch, real_runtime: Path
+):
     """Full pipeline: parse fixture coil.toml, build, verify each exe.
 
     Mocks the .pyc compilation step — we're testing VERSIONINFO wiring,
@@ -107,13 +81,12 @@ def test_bundled_build_stamps_versioninfo_from_fixture(tmp_path: Path, monkeypat
     monkeypatch.setattr("coil.packager.obfuscate_default", _fake_obfuscate)
     monkeypatch.setattr("coil.packager.obfuscate_secure", _fake_obfuscate)
 
-    runtime = _make_real_runtime(tmp_path)
     output = tmp_path / "dist"
 
     bundle = package_bundled(
         project_dir=FIXTURE_DIR,
         output_dir=output,
-        runtime_dir=runtime,
+        runtime_dir=real_runtime,
         entry_points=entries,
         name="AcmeSuite",
         target_os="windows",


### PR DESCRIPTION
Closes #4.

## Summary

- Adds a session-scoped `real_runtime` pytest fixture in `tests/conftest.py` that extracts a cached Windows embeddable Python zip. Six test files consume it, deduplicating three former helper variants.
- Fixes all 9 failures in `tests/test_packager.py`, bringing the suite to 303 passed / 0 failed.

## Bug 1: WinError 216 (8 of 9 failures)

`tests/test_packager.py::_make_runtime` wrote `b"MZ" + b"\x00" * 200` as a fake `python.exe`. Windows `CreateProcess` refused to launch it, so every test that exercised real compilation via `obfuscator.py`'s `subprocess.run([runtime_python], ...)` died with `OSError: [WinError 216] This version of %1 is not compatible with the version of Windows you're running.`

**Fix**: Centralize runtime setup in `tests/conftest.py` as a session-scoped `real_runtime` fixture that extracts a cached Windows embeddable Python zip from `~/.coil/cache/runtimes/`. Skips cleanly when not on Windows or when no cached embeddable is available. The runtime dir is read-only across tests (the packager only copies out, never mutates), so sharing is safe and avoids re-extracting per test.

### Note on the prior "synthetic runtime" pattern

The prompt suggested hoisting `_make_real_runtime` from `test_versioninfo_integration.py` — the "copy host python.exe + DLLs + empty stdlib zip" variant. That approach isn't actually runnable: a copied `python.exe` alongside a `._pth` pointing at an empty zip aborts at init with `ModuleNotFoundError: No module named 'encodings'`. I verified this by running it directly. The versioninfo/subsystem tests only tolerated it because they `monkeypatch` `obfuscate_default` / `obfuscate_secure` to skip real compilation — the "runtime" was just a file layout, never actually invoked.

So the shared fixture uses the cached-embeddable pattern already in `test_default_excludes.py` and `test_sitecustomize_dispatch.py`. This pattern has a real stdlib zip and actually runs; all six consumers now behave consistently.

## Bug 2: `test_strip_installed_packages` (1 of 9)

The test asserted `.dist-info` was removed by the strip routine. But `_strip_installed_packages` deliberately preserves it:

- Commit `b6fd29f` (March 2026) removed `*.dist-info` from `patterns_to_remove` with the note *"packages may use importlib.metadata at runtime to read their own version info"*.
- Commit `5155d8f` made the resolver rely on `importlib.metadata.packages_distributions()` to map imports to distributions at build time — which reads `.dist-info`.

Stripping `.dist-info` would break **both** runtime metadata lookups and build-time package resolution. The test was stale — never updated alongside either commit.

**Fix**: Update the test to assert `.dist-info` is **preserved**, matching the intended behavior. `tests/` and `docs/` are still asserted as removed.

## Side fix

`test_package_bundled` asserted a hard-coded `(result / "python313.dll").is_file()`. That breaks once the runtime version is driven by the host interpreter (e.g. host = 3.12 → `python312.dll`). Replaced with a dynamic lookup via `_get_python_ver_tag(result)`, which is already imported in the file.

## Test plan

- [x] Full suite: 303 passed, 0 failed (was: 294 passed, 9 failed).
- [x] Ran the suite twice locally to confirm no flakiness from the shared fixture.
- [x] `pytest tests/test_packager.py -v` — all 27 tests green.
- [x] Non-Windows CI continues to skip cleanly via existing `skipif` markers.
- [x] No new runtime or test dependencies.
- [x] `_strip_installed_packages` is only referenced at `src/coil/packager.py:643` (deps-install path) and in the test — no external API surface affected.