### PR TITLE
Add VERSIONINFO Comments field to per-entry stamping

### DIFF
--- a/src/coil/config.py
+++ b/src/coil/config.py
@@ -108,7 +108,7 @@ def get_versioninfo_config(
     Returns:
         Dict with keys matching set_version_info kwargs: product_name,
         file_description, file_version, product_version, company_name,
-        legal_copyright, internal_name, original_filename.
+        legal_copyright, internal_name, original_filename, comments.
     """
     build = raw.get("build", {})
     vi = build.get("versioninfo", {}) or {}
@@ -132,6 +132,7 @@ def get_versioninfo_config(
     product_version = _pad_version(pick("product_version", file_version))
     company_name = pick("company_name", "")
     legal_copyright = pick("legal_copyright", "")
+    comments = pick("comments", "")
 
     return {
         "product_name": product_name,
@@ -142,6 +143,7 @@ def get_versioninfo_config(
         "product_version": product_version,
         "company_name": company_name,
         "legal_copyright": legal_copyright,
+        "comments": comments,
     }
 
 

--- a/src/coil/platforms/windows.py
+++ b/src/coil/platforms/windows.py
@@ -284,6 +284,7 @@ def set_version_info(
     legal_copyright: str = "",
     internal_name: str | None = None,
     original_filename: str | None = None,
+    comments: str = "",
 ) -> None:
     """Write VS_VERSION_INFO resource into a PE executable.
 
@@ -300,6 +301,7 @@ def set_version_info(
         legal_copyright: Copyright string for file properties.
         internal_name: InternalName field. Defaults to product_name.
         original_filename: OriginalFilename field. Defaults to exe_path.name.
+        comments: Free-form Comments field for file properties.
     """
     import ctypes
 
@@ -365,6 +367,8 @@ def set_version_info(
         strings["CompanyName"] = company_name
     if legal_copyright:
         strings["LegalCopyright"] = legal_copyright
+    if comments:
+        strings["Comments"] = comments
 
     # Build String entries
     string_entries = b''

--- a/tests/fixtures/versioninfo_sample/coil.toml
+++ b/tests/fixtures/versioninfo_sample/coil.toml
@@ -11,9 +11,11 @@ console = true
 company_name = "Acme Corp"
 product_name = "Acme Suite"
 legal_copyright = "Copyright (c) 2026 Acme Corp"
+comments = "Built by the platform team"
 
 [build.versioninfo.entries.main]
 file_description = "Acme Suite - Main Tool"
+comments = "Built by the platform team - main entry"
 
 [build.versioninfo.entries.worker]
 file_description = "Acme Suite - Worker"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -205,6 +205,7 @@ def test_versioninfo_no_config_defaults():
     assert vi["product_version"] == "1.0.0.0"
     assert vi["company_name"] == ""
     assert vi["legal_copyright"] == ""
+    assert vi["comments"] == ""
 
 
 def test_versioninfo_shared_fields_applied_to_all_entries():
@@ -252,6 +253,48 @@ def test_versioninfo_per_entry_override():
     assert b["product_name"] == "Acme Suite"  # shared
     assert b["file_description"] == "Acme Worker"
     assert b["internal_name"] == "acme-worker"
+
+
+def test_versioninfo_comments_shared():
+    """Shared [build.versioninfo].comments applies to all entries."""
+    raw = {
+        "project": {"name": "Suite"},
+        "build": {
+            "versioninfo": {
+                "comments": "Built by the platform team",
+            }
+        },
+    }
+    a = get_versioninfo_config(raw, entry_name="main", project_name="Suite")
+    b = get_versioninfo_config(raw, entry_name="worker", project_name="Suite")
+    assert a["comments"] == "Built by the platform team"
+    assert b["comments"] == "Built by the platform team"
+
+
+def test_versioninfo_comments_per_entry_override():
+    """Per-entry comments wins over shared comments."""
+    raw = {
+        "project": {"name": "Suite"},
+        "build": {
+            "versioninfo": {
+                "comments": "Shared comment",
+                "entries": {
+                    "main": {"comments": "Main-only comment"},
+                },
+            }
+        },
+    }
+    a = get_versioninfo_config(raw, entry_name="main", project_name="Suite")
+    b = get_versioninfo_config(raw, entry_name="worker", project_name="Suite")
+    assert a["comments"] == "Main-only comment"
+    assert b["comments"] == "Shared comment"
+
+
+def test_versioninfo_comments_default_empty():
+    """When no comments configured anywhere, resolved value is empty string."""
+    raw = {"project": {"name": "App"}}
+    vi = get_versioninfo_config(raw, entry_name="main", project_name="App")
+    assert vi["comments"] == ""
 
 
 def test_versioninfo_version_txt_fallback(tmp_path: Path):

--- a/tests/test_versioninfo_integration.py
+++ b/tests/test_versioninfo_integration.py
@@ -106,6 +106,7 @@ def test_bundled_build_stamps_versioninfo_from_fixture(
             "ProductVersion": "1.2.3.0",
             "InternalName": "main",
             "OriginalFilename": "main.exe",
+            "Comments": "Built by the platform team - main entry",
         },
         "worker.exe": {
             "ProductName": "Acme Suite",
@@ -113,6 +114,7 @@ def test_bundled_build_stamps_versioninfo_from_fixture(
             "CompanyName": "Acme Corp",
             "InternalName": "acme-worker",
             "OriginalFilename": "worker.exe",
+            "Comments": "Built by the platform team",
         },
         "With Spaces.exe": {
             "ProductName": "Acme Suite",
@@ -120,6 +122,7 @@ def test_bundled_build_stamps_versioninfo_from_fixture(
             "CompanyName": "Acme Corp",
             "InternalName": "With Spaces",
             "OriginalFilename": "With Spaces.exe",
+            "Comments": "Built by the platform team",
         },
     }
 

--- a/tests/test_windows_versioninfo.py
+++ b/tests/test_windows_versioninfo.py
@@ -159,9 +159,22 @@ def test_writer_unicode_values(tmp_path: Path):
 
 
 def test_writer_omits_empty_optional_fields(tmp_path: Path):
-    """Empty company_name / legal_copyright are not written as blank strings."""
+    """Empty company_name / legal_copyright / comments are not written as blank strings."""
     exe = _copy_python_exe(tmp_path)
     set_version_info(exe, product_name="Thing")
     strings = _read_version_strings(exe)
     assert "CompanyName" not in strings
     assert "LegalCopyright" not in strings
+    assert "Comments" not in strings
+
+
+def test_writer_stamps_comments(tmp_path: Path):
+    """The new Comments field roundtrips through the writer."""
+    exe = _copy_python_exe(tmp_path)
+    set_version_info(
+        exe,
+        product_name="Thing",
+        comments="Developed by Nathan Curtis",
+    )
+    strings = _read_version_strings(exe)
+    assert strings["Comments"] == "Developed by Nathan Curtis"


### PR DESCRIPTION
## Summary
- Adds support for the standard Windows VERSIONINFO `Comments` string in Coil's per-entry version info stamping (alongside the existing `FileDescription`, `FileVersion`, `InternalName`, `ProductName`, `ProductVersion`, `OriginalFilename`, `CompanyName`, `LegalCopyright`).
- New optional `comments` kwarg on `set_version_info` and matching `comments` field under `[build.versioninfo]` with per-entry overrides via `[build.versioninfo.entries.<stem>]`.
- Empty-string default; empty values are omitted from the stamped resource, matching the existing `CompanyName` / `LegalCopyright` rule so we don't pollute Properties → Details with blank entries.

This retires the downstream workaround of folding developer attribution into `LegalCopyright`. `Comments` is the natural home for free-form metadata like build provenance or developer credit.

## Scope
Only `Comments` is added. `LegalTrademarks`, `PrivateBuild`, `SpecialBuild`, etc. are intentionally left out; each is its own decision.

Backwards compatible: the new kwarg defaults to empty string, so existing callers and configs continue to work unchanged.

## Example config
```toml
[build.versioninfo]
company_name    = "Acme Corp"
product_name    = "Acme Suite"
legal_copyright = "Copyright (c) 2026 Acme Corp"
comments        = "Built by the platform team"

[build.versioninfo.entries.main]
comments = "Built by the platform team - main entry"
```

## Test plan
- [x] Writer roundtrip: `test_writer_stamps_comments` (parses with `pefile`).
- [x] Empty-omission: `test_writer_omits_empty_optional_fields` extended to cover `Comments`.
- [x] Resolver: shared, per-entry override, default-empty unit tests in `test_config.py`.
- [x] Integration: fixture `coil.toml` and `test_versioninfo_integration.py` extended to assert per-entry override and shared inheritance on real built exes.
- [x] Full regression: `pytest` — 307 passed.