### PR TITLE
VERSIONINFO resolver: empty string is an explicit override

### DIFF
--- a/src/coil/config.py
+++ b/src/coil/config.py
@@ -118,10 +118,17 @@ def get_versioninfo_config(
     default_version = _pad_version(version) if version else "1.0.0.0"
 
     def pick(key: str, default: str) -> str:
-        if key in per_entry and per_entry[key] not in (None, ""):
-            return str(per_entry[key])
-        if key in vi and vi[key] not in (None, ""):
-            return str(vi[key])
+        # Explicit-override-wins: presence of the key in per_entry (resp. vi)
+        # is what qualifies as an override, not truthiness. This lets a user
+        # blank out an inherited shared value with `field = ""` on an entry,
+        # which matters for optional fields (company_name, legal_copyright,
+        # comments) that the writer omits when empty.
+        if key in per_entry:
+            v = per_entry[key]
+            return "" if v is None else str(v)
+        if key in vi:
+            v = vi[key]
+            return "" if v is None else str(v)
         return default
 
     product_name = pick("product_name", project_name or entry_name)

--- a/tests/fixtures/versioninfo_sample/coil.toml
+++ b/tests/fixtures/versioninfo_sample/coil.toml
@@ -23,3 +23,8 @@ internal_name = "acme-worker"
 
 [build.versioninfo.entries."With Spaces"]
 file_description = "Acme Suite - Spaced Tool"
+
+[build.versioninfo.entries.no_comment]
+file_description = "Acme Suite - Silent Tool"
+# Explicit empty override: blanks out the shared `comments` for this entry.
+comments = ""

--- a/tests/fixtures/versioninfo_sample/no_comment.py
+++ b/tests/fixtures/versioninfo_sample/no_comment.py
@@ -1,0 +1,1 @@
+print("no_comment")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -297,6 +297,65 @@ def test_versioninfo_comments_default_empty():
     assert vi["comments"] == ""
 
 
+def test_versioninfo_per_entry_empty_overrides_shared_comments():
+    """Per-entry comments = "" explicitly blanks out an inherited shared value."""
+    raw = {
+        "project": {"name": "Suite"},
+        "build": {
+            "versioninfo": {
+                "comments": "Shared comment",
+                "entries": {
+                    "helper": {"comments": ""},
+                },
+            }
+        },
+    }
+    helper = get_versioninfo_config(raw, entry_name="helper", project_name="Suite")
+    worker = get_versioninfo_config(raw, entry_name="worker", project_name="Suite")
+    # Explicit empty override wins.
+    assert helper["comments"] == ""
+    # Sibling entry with no per-entry key still inherits shared.
+    assert worker["comments"] == "Shared comment"
+
+
+def test_versioninfo_per_entry_empty_overrides_shared_company_name():
+    """Empty-override semantics apply uniformly to company_name too."""
+    raw = {
+        "project": {"name": "Suite"},
+        "build": {
+            "versioninfo": {
+                "company_name": "Acme Corp",
+                "entries": {
+                    "helper": {"company_name": ""},
+                },
+            }
+        },
+    }
+    helper = get_versioninfo_config(raw, entry_name="helper", project_name="Suite")
+    worker = get_versioninfo_config(raw, entry_name="worker", project_name="Suite")
+    assert helper["company_name"] == ""
+    assert worker["company_name"] == "Acme Corp"
+
+
+def test_versioninfo_per_entry_empty_overrides_shared_legal_copyright():
+    """Empty-override semantics apply uniformly to legal_copyright too."""
+    raw = {
+        "project": {"name": "Suite"},
+        "build": {
+            "versioninfo": {
+                "legal_copyright": "Copyright (c) 2026 Acme Corp",
+                "entries": {
+                    "helper": {"legal_copyright": ""},
+                },
+            }
+        },
+    }
+    helper = get_versioninfo_config(raw, entry_name="helper", project_name="Suite")
+    worker = get_versioninfo_config(raw, entry_name="worker", project_name="Suite")
+    assert helper["legal_copyright"] == ""
+    assert worker["legal_copyright"] == "Copyright (c) 2026 Acme Corp"
+
+
 def test_versioninfo_version_txt_fallback(tmp_path: Path):
     (tmp_path / "version.txt").write_text("4.5.6", encoding="utf-8")
     raw = {"project": {"name": "App"}}

--- a/tests/test_versioninfo_integration.py
+++ b/tests/test_versioninfo_integration.py
@@ -56,7 +56,7 @@ def test_bundled_build_stamps_versioninfo_from_fixture(
     raw = load_config(FIXTURE_DIR)
     assert raw is not None
 
-    entries = ["main.py", "worker.py", "With Spaces.py"]
+    entries = ["main.py", "worker.py", "With Spaces.py", "no_comment.py"]
     stems = [Path(e).stem for e in entries]
 
     versioninfo = {
@@ -124,6 +124,13 @@ def test_bundled_build_stamps_versioninfo_from_fixture(
             "OriginalFilename": "With Spaces.exe",
             "Comments": "Built by the platform team",
         },
+        "no_comment.exe": {
+            "ProductName": "Acme Suite",
+            "FileDescription": "Acme Suite - Silent Tool",
+            "CompanyName": "Acme Corp",
+            "InternalName": "no_comment",
+            "OriginalFilename": "no_comment.exe",
+        },
     }
 
     for exe_name, want in expected.items():
@@ -136,6 +143,14 @@ def test_bundled_build_stamps_versioninfo_from_fixture(
             )
         # Canary: must not have inherited python.exe's FileDescription
         assert got["FileDescription"].lower() != "python"
+
+    # Explicit empty override on no_comment must blank out the shared
+    # `comments` value — the writer omits empty optional fields, so Comments
+    # should not appear in the stamped PE at all.
+    silent = _read_version_strings(bundle / "no_comment.exe")
+    assert "Comments" not in silent, (
+        f"no_comment.exe should have no Comments (got {silent.get('Comments')!r})"
+    )
 
 
 def test_bundled_build_with_quoted_stem_loads_and_stamps(tmp_path: Path):

--- a/tests/test_windows_versioninfo.py
+++ b/tests/test_windows_versioninfo.py
@@ -98,6 +98,7 @@ def test_writer_stamps_all_fields(tmp_path: Path):
         legal_copyright="Copyright (c) 2026 Acme Corp",
         internal_name="acme-main",
         original_filename="app.exe",
+        comments="Built by the platform team",
     )
 
     strings = _read_version_strings(exe)
@@ -109,6 +110,7 @@ def test_writer_stamps_all_fields(tmp_path: Path):
     assert strings["LegalCopyright"] == "Copyright (c) 2026 Acme Corp"
     assert strings["InternalName"] == "acme-main"
     assert strings["OriginalFilename"] == "app.exe"
+    assert strings["Comments"] == "Built by the platform team"
 
 
 def test_writer_evicts_python_filedescription(tmp_path: Path):


### PR DESCRIPTION
## Summary

Two small follow-ups from the review of #9:

1. **Resolver fix:** `pick()` in `get_versioninfo_config` treated `field = ""` as "unset" and fell through to the next level. This silently ignored a user's attempt to blank out an inherited value — e.g. `[build.versioninfo.entries.helper].comments = ""` to suppress a shared `[build.versioninfo].comments` on just one entry. Now: presence of the key is the override signal regardless of value; only absent keys fall through.

2. **Parity fix:** `test_writer_stamps_all_fields` enumerates every writer field but was never updated when `comments` landed. Extended to include it.

## Depends on #9

This branch is stacked on `add-versioninfo-comments` — the diff shown here includes #9's commit until that merges. Once #9 lands, this PR's diff naturally collapses to just the follow-up changes.

## Why uniform, not optional-fields-only

The same class of bug exists for required fields too — a user writing `file_description = ""` on one entry is plausibly trying to blank out an inherited shared value, and silently falling through to the entry stem violates their intent the same way it does for `comments`. Uniform mental model > special-casing. The edge case of someone writing `product_name = ""` and getting a blank-stamped PE is degenerate; if a user does it, they get what they asked for.

The writer's existing omit-when-empty behavior (for `CompanyName` / `LegalCopyright` / `Comments`) handles the common case correctly: empty-string resolution → field doesn't appear in the produced exe's VERSIONINFO.

## Test plan

- [x] New resolver tests (would fail against old `pick()`): per-entry `""` overrides shared non-empty for `comments`, `company_name`, `legal_copyright`.
- [x] Integration: fixture gains a `no_comment` entry with `comments = ""` against shared `comments = "Built by the platform team"`; produced `no_comment.exe` has no `Comments` string in its VERSIONINFO.
- [x] Writer: `test_writer_stamps_all_fields` now includes `comments` and asserts it.
- [x] Full regression: `pytest` — 310 passed.