### PR TITLE
Exclude tests/, test/, memory/, .cursor/ from bundles by default

### DIFF
--- a/src/coil/packager.py
+++ b/src/coil/packager.py
@@ -839,10 +839,15 @@ DEFAULT_EXCLUDE_PATTERNS: list[str] = [
     ".github/",
     ".vscode/",
     ".idea/",
+    ".cursor/",
     ".gitignore",
     ".gitattributes",
     ".editorconfig",
     ".coilignore",
+    # Test scaffolding and AI-assistant scratch
+    "tests/",
+    "test/",
+    "memory/",
     # Virtualenvs / dependency trees
     ".venv/",
     "venv/",

--- a/tests/test_default_excludes.py
+++ b/tests/test_default_excludes.py
@@ -214,6 +214,35 @@ def test_negation_cannot_reinclude_from_excluded_dir(tmp_path: Path):
     assert matches(tmp_path / "build" / "keepme.txt")
 
 
+def test_defaults_exclude_tests_memory_and_ai_state(tmp_path: Path):
+    """tests/, test/, memory/, .cursor/ — plus .vscode/, .idea/ as regression
+    guards — should all be caught by DEFAULT_EXCLUDE_PATTERNS."""
+    _touch(
+        tmp_path,
+        "tests/",
+        "test/",
+        "memory/",
+        ".cursor/",
+        ".vscode/",
+        ".idea/",
+    )
+    matches = _build_exclude_matcher(tmp_path)
+    for rel in ["tests", "test", "memory", ".cursor", ".vscode", ".idea"]:
+        assert matches(tmp_path / rel), f"expected default exclude for {rel}"
+
+
+def test_user_negation_reincludes_tests_directory(tmp_path: Path):
+    """Escape hatch: a project that legitimately ships a fixture-driven
+    self-test path can `!tests/` in .coilignore to re-include it — both the
+    directory itself and everything under it."""
+    _touch(tmp_path, "tests/fixtures/data.json")
+    (tmp_path / ".coilignore").write_text("!tests/\n", encoding="utf-8")
+    matches = _build_exclude_matcher(tmp_path)
+    assert not matches(tmp_path / "tests")
+    assert not matches(tmp_path / "tests" / "fixtures")
+    assert not matches(tmp_path / "tests" / "fixtures" / "data.json")
+
+
 def test_dir_pattern_doesnt_match_file_of_same_name(tmp_path: Path):
     """A pattern like `Output/` should not exclude a file literally named
     `Output` (no extension)."""
@@ -262,7 +291,10 @@ def test_bundled_build_does_not_leak_project_noise(tmp_path: Path, real_runtime:
         "Makefile",
     ]:
         (project / name).write_text("noise\n", encoding="utf-8")
-    for dname in [".github", "__pycache__", "Output", "pkg.egg-info", ".venv", "build", "dist"]:
+    for dname in [
+        ".github", "__pycache__", "Output", "pkg.egg-info", ".venv", "build", "dist",
+        "tests", "test", "memory", ".cursor",
+    ]:
         (project / dname).mkdir()
         (project / dname / "leaked.txt").write_text("leak\n", encoding="utf-8")
 
@@ -299,6 +331,7 @@ def test_bundled_build_does_not_leak_project_noise(tmp_path: Path, real_runtime:
         assert should_miss not in root_files, f"{should_miss} leaked into bundle root"
     for should_miss in [
         ".github", "__pycache__", "Output", "pkg.egg-info", ".venv", "build", "dist",
+        "tests", "test", "memory", ".cursor",
     ]:
         assert should_miss not in root_dirs, f"{should_miss}/ leaked into bundle root"
 


### PR DESCRIPTION
## Summary

Closes #10
Closes #11

Adds four entries to `DEFAULT_EXCLUDE_PATTERNS` in `src/coil/packager.py` so that downstream bundles stop leaking dev-time directories:

- `tests/` and `test/` — issue #10
- `memory/` — issue #11 (Claude Code per-project memory store)
- `.cursor/` — issue #11 (Cursor IDE state)

### Why the diff is smaller than issue #11 implies

Issue #11 lists `memory/`, `.cursor/`, `.vscode/`, `.idea/`. The last two were already in `DEFAULT_EXCLUDE_PATTERNS` (landed in PR #7), so the actual new entries for that issue are just `memory/` and `.cursor/`. The existing defaults are verified by a new regression-guard assertion in `test_defaults_exclude_tests_memory_and_ai_state`.

### Option A (explicit list) vs Option B (`.*/` glob) — picked A

The existing list is emphatically explicit: `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`, `.tox/`, `.vscode/`, `.idea/`, `.github/`, `.git/` are each spelled out. Switching to a dot-prefix glob would have meant deleting 6+ existing entries as redundant, which crosses from "add defaults" into redesigning the exclude mechanism. Explicit stays predictable and greppable; the growth rate is a handful of entries per decade.

### Escape hatch still works

Users who legitimately ship a fixture-driven self-test path can put `!tests/` in `.coilignore`. New unit test `test_user_negation_reincludes_tests_directory` proves this: `!tests/` re-includes the directory itself and every file under it. The behavior falls out of the existing last-match-wins semantics in `_eval_patterns` (no parser change needed).

## Test plan

- [x] New unit test `test_defaults_exclude_tests_memory_and_ai_state` — asserts `tests/`, `test/`, `memory/`, `.cursor/`, `.vscode/`, `.idea/` are all caught by `_build_exclude_matcher`
- [x] New unit test `test_user_negation_reincludes_tests_directory` — `!tests/` in `.coilignore` re-includes the dir and its children
- [x] Extended integration test `test_bundled_build_does_not_leak_project_noise` — the new dir names are mixed into the existing noise-fixture and asserted absent from the produced bundle root via `package_bundled`
- [x] Full suite: `312 passed` (was 310 before this PR, +2 new unit tests; integration test extended in place)