### PR TITLE
Exclude testing/ from bundles by default

### DIFF
--- a/src/coil/packager.py
+++ b/src/coil/packager.py
@@ -847,6 +847,7 @@ DEFAULT_EXCLUDE_PATTERNS: list[str] = [
     # Test scaffolding and AI-assistant scratch
     "tests/",
     "test/",
+    "testing/",
     "memory/",
     # Virtualenvs / dependency trees
     ".venv/",

--- a/tests/test_default_excludes.py
+++ b/tests/test_default_excludes.py
@@ -215,19 +215,20 @@ def test_negation_cannot_reinclude_from_excluded_dir(tmp_path: Path):
 
 
 def test_defaults_exclude_tests_memory_and_ai_state(tmp_path: Path):
-    """tests/, test/, memory/, .cursor/ — plus .vscode/, .idea/ as regression
-    guards — should all be caught by DEFAULT_EXCLUDE_PATTERNS."""
+    """tests/, test/, testing/, memory/, .cursor/ — plus .vscode/, .idea/ as
+    regression guards — should all be caught by DEFAULT_EXCLUDE_PATTERNS."""
     _touch(
         tmp_path,
         "tests/",
         "test/",
+        "testing/",
         "memory/",
         ".cursor/",
         ".vscode/",
         ".idea/",
     )
     matches = _build_exclude_matcher(tmp_path)
-    for rel in ["tests", "test", "memory", ".cursor", ".vscode", ".idea"]:
+    for rel in ["tests", "test", "testing", "memory", ".cursor", ".vscode", ".idea"]:
         assert matches(tmp_path / rel), f"expected default exclude for {rel}"
 
 
@@ -293,7 +294,7 @@ def test_bundled_build_does_not_leak_project_noise(tmp_path: Path, real_runtime:
         (project / name).write_text("noise\n", encoding="utf-8")
     for dname in [
         ".github", "__pycache__", "Output", "pkg.egg-info", ".venv", "build", "dist",
-        "tests", "test", "memory", ".cursor",
+        "tests", "test", "testing", "memory", ".cursor",
     ]:
         (project / dname).mkdir()
         (project / dname / "leaked.txt").write_text("leak\n", encoding="utf-8")
@@ -331,7 +332,7 @@ def test_bundled_build_does_not_leak_project_noise(tmp_path: Path, real_runtime:
         assert should_miss not in root_files, f"{should_miss} leaked into bundle root"
     for should_miss in [
         ".github", "__pycache__", "Output", "pkg.egg-info", ".venv", "build", "dist",
-        "tests", "test", "memory", ".cursor",
+        "tests", "test", "testing", "memory", ".cursor",
     ]:
         assert should_miss not in root_dirs, f"{should_miss}/ leaked into bundle root"
 


### PR DESCRIPTION
## Summary

Adds `testing/` to `DEFAULT_EXCLUDE_PATTERNS` next to the existing `tests/` and `test/` entries (added in PR #13). `testing/` (singular `-ing` form) is a less common but conventional test-directory naming choice — especially in older Python projects — and deserves the same default exclusion.

Surfaced when building OPP Puller (a downstream Ronsin Windows app) with Coil 0.2.3: `testing/` leaked into `dist/OPP Puller/testing/` and required manual `rm -rf` before installer compile.

## What changed

- One-line addition to `DEFAULT_EXCLUDE_PATTERNS` in `src/coil/packager.py`.
- Existing `test_defaults_exclude_tests_memory_and_ai_state` extended to cover `testing/`.
- Existing `test_bundled_build_does_not_leak_project_noise` extended to cover `testing/`.

## Test plan

- [x] `tests/test_default_excludes.py` — 21 passed locally (was 20 before, +1 from the extended unit test). Integration test extension passes.
- [x] `.coilignore` negation continues to work (`!testing/` re-includes), since the negation behavior is pattern-agnostic and was already proven by `test_user_negation_reincludes_tests_directory`.

## Out of scope

Other potential variants (`tmp/`, `scratch/`, `_tests/`, etc.) — only have direct evidence of `testing/` leaking. Would bundle additional variants in a follow-up if they come up across more apps.

Closes #14